### PR TITLE
refactor(llmrails): extract startup config loading

### DIFF
--- a/nemoguardrails/rails/llm/startup/__init__.py
+++ b/nemoguardrails/rails/llm/startup/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []

--- a/nemoguardrails/rails/llm/startup/colang_flows.py
+++ b/nemoguardrails/rails/llm/startup/colang_flows.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Colang flow loading, rail flow marking, and rail config validation."""
+
+import importlib.resources as resources
+import logging
+from collections.abc import Iterator
+from importlib.abc import Traversable
+
+from nemoguardrails.colang import parse_colang_file
+from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.rails.llm.config import RailsConfig
+
+log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+
+_NEMOGUARDRAILS_PACKAGE = "nemoguardrails"
+
+__all__ = [
+    "load_default_colang_1_flows",
+    "load_guardrails_library_flows_and_bot_messages",
+    "mark_rail_flows_as_system_subflows",
+    "validate_rail_flow_names",
+]
+
+
+def _package_resource(*parts: str) -> Traversable:
+    resource = resources.files(_NEMOGUARDRAILS_PACKAGE)
+    for part in parts:
+        resource = resource.joinpath(part)
+    return resource
+
+
+def _iter_colang_resources(resource: Traversable) -> Iterator[Traversable]:
+    if resource.is_file():
+        if resource.name.endswith(".co"):
+            yield resource
+        return
+
+    # Sort children by name so the library load order is deterministic and independent
+    # of the filesystem's directory-iteration order. ``bot_messages`` are inserted on a
+    # first-seen-wins basis, so a non-deterministic order can change which utterances win.
+    children = sorted(resource.iterdir(), key=lambda child: child.name)
+    for child in children:
+        if child.is_file() and child.name.endswith(".co"):
+            yield child
+
+    for child in children:
+        if child.is_dir():
+            yield from _iter_colang_resources(child)
+
+
+def load_default_colang_1_flows(config: RailsConfig) -> None:
+    """Load the built-in Colang 1.0 LLM flows into the rails config."""
+    if config.colang_version != "1.0":
+        return
+
+    default_flows_resource = _package_resource("rails", "llm", "llm_flows.co")
+    default_flows_content = default_flows_resource.read_text(encoding="utf-8")
+    default_flows = parse_colang_file(default_flows_resource.name, default_flows_content)["flows"]
+
+    for flow_config in default_flows:
+        flow_config["is_system_flow"] = True
+
+    config.flows.extend(default_flows)
+
+
+def load_guardrails_library_flows_and_bot_messages(config: RailsConfig) -> None:
+    """Load Colang 1.0 flows and bot messages from the guardrails library."""
+    if config.colang_version != "1.0":
+        return
+
+    library_resource = _package_resource("library")
+    for colang_resource in _iter_colang_resources(library_resource):
+        log.debug(f"Loading file: {colang_resource}")
+        content = parse_colang_file(
+            colang_resource.name,
+            content=colang_resource.read_text(encoding="utf-8"),
+            version=config.colang_version,
+        )
+        if not content:
+            continue
+
+        for flow_config in content["flows"]:
+            flow_config["is_system_flow"] = True
+
+        config.flows.extend(content["flows"])
+
+        for message_id, utterances in content.get("bot_messages", {}).items():
+            if message_id not in config.bot_messages:
+                config.bot_messages[message_id] = utterances
+
+
+def mark_rail_flows_as_system_subflows(config: RailsConfig) -> None:
+    """Mark configured input, output, and retrieval rail flows as system subflows."""
+    rail_flow_ids = config.rails.input.flows + config.rails.output.flows + config.rails.retrieval.flows
+
+    for flow_config in config.flows:
+        if flow_config.get("id") in rail_flow_ids:
+            flow_config["is_system_flow"] = True
+            flow_config["is_subflow"] = True
+
+
+def validate_rail_flow_names(config: RailsConfig) -> None:
+    """Validate that configured rail flows exist in the config."""
+    if config.colang_version == "1.0":
+        existing_flows_names = set([flow.get("id") for flow in config.flows])
+    else:
+        existing_flows_names = set([flow.get("name") for flow in config.flows])
+
+    for flow_name in config.rails.input.flows:
+        flow_name = _normalize_flow_id(flow_name)
+        if flow_name not in existing_flows_names:
+            raise InvalidRailsConfigurationError(f"The provided input rail flow `{flow_name}` does not exist")
+
+    for flow_name in config.rails.output.flows:
+        flow_name = _normalize_flow_id(flow_name)
+        if flow_name not in existing_flows_names:
+            raise InvalidRailsConfigurationError(f"The provided output rail flow `{flow_name}` does not exist")
+
+    for flow_name in config.rails.retrieval.flows:
+        if flow_name not in existing_flows_names:
+            raise InvalidRailsConfigurationError(f"The provided retrieval rail flow `{flow_name}` does not exist")

--- a/nemoguardrails/rails/llm/startup/config_preparation.py
+++ b/nemoguardrails/rails/llm/startup/config_preparation.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLMRails config preparation."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.startup.colang_flows import (
+    load_default_colang_1_flows,
+    load_guardrails_library_flows_and_bot_messages,
+    mark_rail_flows_as_system_subflows,
+)
+from nemoguardrails.rails.llm.startup.embedding_search import apply_embedding_model_config
+
+_COLANG_FLOWS_PREPARED_ATTR = "_llmrails_colang_flows_prepared"
+
+__all__ = ["PreparedLLMRailsConfig", "prepare_llmrails_config"]
+
+
+@dataclass
+class PreparedLLMRailsConfig:
+    config: RailsConfig
+    default_embedding_model: Optional[str]
+    default_embedding_engine: Optional[str]
+    default_embedding_params: Dict[str, Any]
+
+
+def prepare_llmrails_config(
+    *,
+    config: RailsConfig,
+    default_embedding_model: Optional[str],
+    default_embedding_engine: Optional[str],
+    default_embedding_params: Dict[str, Any],
+    in_place: bool = True,
+) -> PreparedLLMRailsConfig:
+    """Prepare a RailsConfig for the standard LLMRails runtime."""
+    prepared_config = config if in_place else config.model_copy(deep=True)
+
+    if not getattr(prepared_config, _COLANG_FLOWS_PREPARED_ATTR, False):
+        load_default_colang_1_flows(prepared_config)
+        load_guardrails_library_flows_and_bot_messages(prepared_config)
+        setattr(prepared_config, _COLANG_FLOWS_PREPARED_ATTR, True)
+
+    mark_rail_flows_as_system_subflows(prepared_config)
+
+    (
+        default_embedding_model,
+        default_embedding_engine,
+        default_embedding_params,
+    ) = apply_embedding_model_config(
+        config=prepared_config,
+        default_embedding_model=default_embedding_model,
+        default_embedding_engine=default_embedding_engine,
+        default_embedding_params=default_embedding_params,
+    )
+
+    return PreparedLLMRailsConfig(
+        config=prepared_config,
+        default_embedding_model=default_embedding_model,
+        default_embedding_engine=default_embedding_engine,
+        default_embedding_params=default_embedding_params,
+    )

--- a/nemoguardrails/rails/llm/startup/config_py.py
+++ b/nemoguardrails/rails/llm/startup/config_py.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config.py module hooks."""
+
+import importlib.util
+import os
+from types import ModuleType
+from typing import Any, List
+
+from nemoguardrails.rails.llm.config import RailsConfig
+
+__all__ = ["load_config_py_modules", "run_config_py_init_hooks"]
+
+
+def load_config_py_modules(config: RailsConfig) -> List[ModuleType]:
+    """Load config.py modules from imported config paths and the main config path."""
+    config_modules = []
+    config_paths = list(config.imported_paths.values() if config.imported_paths else []) + [config.config_path]
+
+    for config_path in config_paths:
+        if not config_path:
+            continue
+
+        filepath = os.path.join(config_path, "config.py")
+        if not os.path.exists(filepath):
+            continue
+
+        filename = os.path.basename(filepath)
+        spec = importlib.util.spec_from_file_location(filename, filepath)
+        if spec and spec.loader:
+            config_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(config_module)
+            config_modules.append(config_module)
+
+    return config_modules
+
+
+def run_config_py_init_hooks(rails: Any, config_modules: List[ModuleType]) -> None:
+    """Run config.py init hooks with the LLMRails instance."""
+    for config_module in config_modules:
+        if hasattr(config_module, "init"):
+            config_module.init(rails)

--- a/nemoguardrails/rails/llm/startup/config_validation.py
+++ b/nemoguardrails/rails/llm/startup/config_validation.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLMRails startup config validation."""
+
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.startup.colang_flows import validate_rail_flow_names
+
+__all__ = ["validate_llmrails_config"]
+
+
+def validate_llmrails_config(config: RailsConfig) -> None:
+    validate_rail_flow_names(config)
+
+    if config.passthrough and config.rails.dialog.single_call.enabled:
+        raise InvalidRailsConfigurationError(
+            "The passthrough mode and the single call dialog rails mode can't be used at the same time. "
+            "The single call mode needs to use an altered prompt when prompting the LLM. "
+        )

--- a/nemoguardrails/rails/llm/startup/embedding_search.py
+++ b/nemoguardrails/rails/llm/startup/embedding_search.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Embedding search provider setup."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple, Type
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
+
+DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+DEFAULT_EMBEDDING_ENGINE = "FastEmbed"
+
+__all__ = [
+    "DEFAULT_EMBEDDING_ENGINE",
+    "DEFAULT_EMBEDDING_MODEL",
+    "EmbeddingSearchState",
+    "apply_embedding_model_config",
+    "get_embedding_search_provider_instance",
+]
+
+
+@dataclass
+class EmbeddingSearchState:
+    providers: Dict[str, Type[EmbeddingsIndex]]
+    default_model: Optional[str]
+    default_engine: Optional[str]
+    default_params: Dict[str, Any]
+
+    @classmethod
+    def default(cls) -> "EmbeddingSearchState":
+        return cls(
+            providers={},
+            default_model=DEFAULT_EMBEDDING_MODEL,
+            default_engine=DEFAULT_EMBEDDING_ENGINE,
+            default_params={},
+        )
+
+    def update_defaults(
+        self,
+        *,
+        default_model: Optional[str],
+        default_engine: Optional[str],
+        default_params: Dict[str, Any],
+    ) -> None:
+        self.default_model = default_model
+        self.default_engine = default_engine
+        self.default_params = default_params
+
+    def register_provider(self, name: str, cls: Type[EmbeddingsIndex]) -> None:
+        self.providers[name] = cls
+
+    def get_provider_instance(
+        self,
+        esp_config: Optional[EmbeddingSearchProvider] = None,
+    ) -> EmbeddingsIndex:
+        return get_embedding_search_provider_instance(
+            embedding_search_providers=self.providers,
+            default_embedding_model=self.default_model,
+            default_embedding_engine=self.default_engine,
+            default_embedding_params=self.default_params,
+            esp_config=esp_config,
+        )
+
+
+def apply_embedding_model_config(
+    config: RailsConfig,
+    default_embedding_model: Optional[str],
+    default_embedding_engine: Optional[str],
+    default_embedding_params: Dict[str, Any],
+) -> Tuple[Optional[str], Optional[str], Dict[str, Any]]:
+    """Apply an embeddings model config to the default embedding search settings."""
+    for model in config.models:
+        if model.type != "embeddings":
+            continue
+
+        default_embedding_model = model.model
+        default_embedding_engine = model.engine
+        default_embedding_params = model.parameters or {}
+
+        for esp in [
+            config.core.embedding_search_provider,
+            config.knowledge_base.embedding_search_provider,
+        ]:
+            if esp.name != "default":
+                continue
+            if "embedding_model" not in esp.parameters and model.model is not None:
+                esp.parameters["embedding_model"] = model.model
+            if "embedding_engine" not in esp.parameters and model.engine is not None:
+                esp.parameters["embedding_engine"] = model.engine
+
+        break
+
+    return default_embedding_model, default_embedding_engine, default_embedding_params
+
+
+def get_embedding_search_provider_instance(
+    embedding_search_providers: Dict[str, Type[EmbeddingsIndex]],
+    default_embedding_model: Optional[str],
+    default_embedding_engine: Optional[str],
+    default_embedding_params: Dict[str, Any],
+    esp_config: Optional[EmbeddingSearchProvider] = None,
+) -> EmbeddingsIndex:
+    """Create the embedding search provider selected by a provider config."""
+    if esp_config is None:
+        esp_config = EmbeddingSearchProvider()
+
+    if esp_config.name == "default":
+        from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
+
+        return BasicEmbeddingsIndex(
+            embedding_model=esp_config.parameters.get("embedding_model", default_embedding_model),
+            embedding_engine=esp_config.parameters.get("embedding_engine", default_embedding_engine),
+            embedding_params=esp_config.parameters.get("embedding_parameters", default_embedding_params),
+            cache_config=esp_config.cache,
+            **{
+                k: v
+                for k, v in esp_config.parameters.items()
+                if k
+                in [
+                    "use_batching",
+                    "max_batch_size",
+                    "matx_batch_hold",
+                    "search_threshold",
+                ]
+                and v is not None
+            },
+        )
+
+    if esp_config.name not in embedding_search_providers:
+        raise Exception(f"Unknown embedding search provider: {esp_config.name}")
+
+    kwargs = esp_config.parameters
+    return embedding_search_providers[esp_config.name](**kwargs)

--- a/tests/rails/llm/test_colang_flows.py
+++ b/tests/rails/llm/test_colang_flows.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import nemoguardrails.rails.llm.startup.colang_flows as colang_flows
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.startup.colang_flows import (
+    load_default_colang_1_flows,
+    load_guardrails_library_flows_and_bot_messages,
+    mark_rail_flows_as_system_subflows,
+    validate_rail_flow_names,
+)
+
+
+def test_load_default_colang_1_flows_marks_loaded_flows_as_system():
+    config = RailsConfig(models=[])
+
+    load_default_colang_1_flows(config)
+
+    assert config.flows
+    assert "process user input" in {flow.get("id") for flow in config.flows}
+    assert all(flow.get("is_system_flow") is True for flow in config.flows)
+
+
+def test_load_guardrails_library_flows_and_bot_messages_loads_package_resources():
+    config = RailsConfig(models=[])
+
+    load_guardrails_library_flows_and_bot_messages(config)
+
+    flow_ids = {flow.get("id") for flow in config.flows}
+    assert "content safety check input" in flow_ids
+    assert "regex check input" in flow_ids
+    assert all(flow.get("is_system_flow") is True for flow in config.flows)
+    assert config.bot_messages["refuse to respond"] == ["I'm sorry, I can't respond to that."]
+    assert config.bot_messages["inform cannot engage with sensitive content"] == [
+        "I will not engage with sensitive content."
+    ]
+
+
+def test_load_guardrails_library_flows_and_bot_messages_keeps_existing_bot_messages():
+    config = RailsConfig(
+        models=[],
+        bot_messages={"refuse to respond": ["Custom refusal."]},
+    )
+
+    load_guardrails_library_flows_and_bot_messages(config)
+
+    assert config.bot_messages["refuse to respond"] == ["Custom refusal."]
+    assert config.bot_messages["inform cannot engage with sensitive content"] == [
+        "I will not engage with sensitive content."
+    ]
+
+
+def test_colang_flow_loading_does_not_depend_on_colang_flows_file_location(monkeypatch, tmp_path):
+    monkeypatch.setattr(colang_flows, "__file__", str(tmp_path / "moved" / "colang_flows.py"))
+
+    default_config = RailsConfig(models=[])
+    colang_flows.load_default_colang_1_flows(default_config)
+
+    library_config = RailsConfig(models=[])
+    colang_flows.load_guardrails_library_flows_and_bot_messages(library_config)
+
+    assert "process user input" in {flow.get("id") for flow in default_config.flows}
+    assert "content safety check input" in {flow.get("id") for flow in library_config.flows}
+    assert library_config.bot_messages["inform cannot engage with sensitive content"] == [
+        "I will not engage with sensitive content."
+    ]
+
+
+def test_mark_rail_flows_as_system_subflows_mutates_matching_flow_configs():
+    config = RailsConfig(
+        models=[],
+        flows=[
+            {"id": "check input", "is_system_flow": False},
+            {"id": "regular flow", "is_system_flow": False},
+        ],
+    )
+    config.rails.input.flows = ["check input"]
+
+    mark_rail_flows_as_system_subflows(config)
+
+    assert config.flows[0]["is_system_flow"] is True
+    assert config.flows[0]["is_subflow"] is True
+    assert config.flows[1]["is_system_flow"] is False
+    assert "is_subflow" not in config.flows[1]
+
+
+class _FakeResource:
+    """Minimal Traversable stand-in whose ``iterdir`` order we control."""
+
+    def __init__(self, name, *, is_dir=False, children=None):
+        self._name = name
+        self._is_dir = is_dir
+        self._children = children or []
+
+    @property
+    def name(self):
+        return self._name
+
+    def is_file(self):
+        return not self._is_dir
+
+    def is_dir(self):
+        return self._is_dir
+
+    def iterdir(self):
+        return iter(self._children)
+
+
+def test_iter_colang_resources_yields_sorted_filesystem_independent_order():
+    # iterdir() returns children in an arbitrary (here: unsorted) order; the traversal
+    # must still yield .co files in a deterministic, sorted order so the library load
+    # order does not depend on the filesystem (the dropped os.walk + sort behavior).
+    resource = _FakeResource(
+        "library",
+        is_dir=True,
+        children=[
+            _FakeResource("zebra.co"),
+            _FakeResource("alpha.co"),
+            _FakeResource("not_colang.txt"),
+            _FakeResource(
+                "subpack",
+                is_dir=True,
+                children=[_FakeResource("yray.co"), _FakeResource("beta.co")],
+            ),
+            _FakeResource("middle.co"),
+        ],
+    )
+
+    names = [item.name for item in colang_flows._iter_colang_resources(resource)]
+
+    # Files in the directory come first (sorted), then sorted subdirectories are
+    # descended into (their files sorted); non-.co files are skipped.
+    assert names == ["alpha.co", "middle.co", "zebra.co", "beta.co", "yray.co"]
+
+
+def test_iter_colang_resources_order_does_not_depend_on_iterdir_order():
+    # The same children in two different iterdir() orders must yield the same sequence.
+    files_forward = [_FakeResource(f"{name}.co") for name in ("a", "b", "c")]
+    files_reversed = list(reversed(files_forward))
+
+    forward = [
+        r.name for r in colang_flows._iter_colang_resources(_FakeResource("d", is_dir=True, children=files_forward))
+    ]
+    backward = [
+        r.name for r in colang_flows._iter_colang_resources(_FakeResource("d", is_dir=True, children=files_reversed))
+    ]
+
+    assert forward == backward == ["a.co", "b.co", "c.co"]
+
+
+def test_validate_rail_flow_names_keeps_existing_flow_validation_behavior():
+    config = RailsConfig(
+        models=[],
+        flows=[{"id": "content safety check input"}],
+    )
+    config.rails.input.flows = ["content safety check input $model=content_safety"]
+
+    validate_rail_flow_names(config)
+
+    config.rails.output.flows = ["missing output rail"]
+    with pytest.raises(InvalidRailsConfigurationError, match="`missing output rail` does not exist"):
+        validate_rail_flow_names(config)

--- a/tests/rails/llm/test_config_preparation.py
+++ b/tests/rails/llm/test_config_preparation.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.rails.llm.config import Model, RailsConfig
+from nemoguardrails.rails.llm.startup import config_preparation as startup_config_preparation
+from nemoguardrails.rails.llm.startup.config_preparation import (
+    prepare_llmrails_config,
+)
+from nemoguardrails.rails.llm.startup.embedding_search import (
+    DEFAULT_EMBEDDING_ENGINE,
+    DEFAULT_EMBEDDING_MODEL,
+)
+
+
+def test_config_preparation_startup_module_exports_public_helpers():
+    assert startup_config_preparation.__all__ == [
+        "PreparedLLMRailsConfig",
+        "prepare_llmrails_config",
+    ]
+
+
+def test_prepare_llmrails_config_loads_colang_flows_once_in_place():
+    config = RailsConfig(models=[])
+
+    first = prepare_llmrails_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+    )
+    first_flow_count = len(config.flows)
+
+    second = prepare_llmrails_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+    )
+
+    assert first.config is config
+    assert second.config is config
+    assert first_flow_count > 0
+    assert len(config.flows) == first_flow_count
+
+
+def test_prepare_llmrails_config_marks_rail_flows_each_time():
+    config = RailsConfig(
+        models=[],
+        flows=[{"id": "check input", "is_system_flow": False}],
+    )
+
+    prepare_llmrails_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+    )
+
+    config.rails.input.flows = ["check input"]
+    prepare_llmrails_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+    )
+
+    assert config.flows[0]["is_system_flow"] is True
+    assert config.flows[0]["is_subflow"] is True
+
+
+def test_prepare_llmrails_config_can_prepare_a_copy():
+    config = RailsConfig(models=[])
+
+    prepared = prepare_llmrails_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+        in_place=False,
+    )
+
+    assert prepared.config is not config
+    assert len(config.flows) == 0
+    assert len(prepared.config.flows) > 0
+
+
+def test_prepare_llmrails_config_returns_embedding_defaults():
+    config = RailsConfig(
+        models=[
+            Model(
+                type="embeddings",
+                engine="SentenceTransformers",
+                model="intfloat/e5-large-v2",
+                parameters={"device": "cpu"},
+            )
+        ],
+    )
+
+    prepared = prepare_llmrails_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+    )
+
+    assert prepared.default_embedding_model == "intfloat/e5-large-v2"
+    assert prepared.default_embedding_engine == "SentenceTransformers"
+    assert prepared.default_embedding_params == {"device": "cpu"}
+    assert config.core.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"

--- a/tests/rails/llm/test_config_py.py
+++ b/tests/rails/llm/test_config_py.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import ModuleType
+
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.llmrails import LLMRails
+from nemoguardrails.rails.llm.startup.config_py import (
+    load_config_py_modules,
+    run_config_py_init_hooks,
+)
+
+
+def test_load_config_py_modules_preserves_imported_then_main_order(tmp_path):
+    imported_path = tmp_path / "imported"
+    main_path = tmp_path / "main"
+    imported_path.mkdir()
+    main_path.mkdir()
+    (imported_path / "config.py").write_text("SOURCE = 'imported'\n")
+    (main_path / "config.py").write_text("SOURCE = 'main'\n")
+
+    config = RailsConfig(
+        config_path=str(main_path),
+        imported_paths={"imported": str(imported_path)},
+        models=[],
+    )
+
+    config_modules = load_config_py_modules(config)
+
+    assert [config_module.SOURCE for config_module in config_modules] == [
+        "imported",
+        "main",
+    ]
+
+
+def test_load_config_py_modules_skips_missing_paths(tmp_path):
+    main_path = tmp_path / "main"
+    imported_path = tmp_path / "imported"
+    main_path.mkdir()
+    imported_path.mkdir()
+    (main_path / "config.py").write_text("SOURCE = 'main'\n")
+
+    config = RailsConfig(
+        config_path=str(main_path),
+        imported_paths={"imported": str(imported_path)},
+        models=[],
+    )
+
+    config_modules = load_config_py_modules(config)
+
+    assert [config_module.SOURCE for config_module in config_modules] == ["main"]
+
+
+def test_llmrails_runs_imported_config_py_init_before_main(tmp_path):
+    imported_path = tmp_path / "imported"
+    main_path = tmp_path / "main"
+    imported_path.mkdir()
+    main_path.mkdir()
+    (imported_path / "config.py").write_text("def init(app):\n    app.hook_order = ['imported']\n")
+    (main_path / "config.py").write_text("def init(app):\n    app.hook_order.append('main')\n")
+
+    config = RailsConfig(
+        config_path=str(main_path),
+        imported_paths={"imported": str(imported_path)},
+        models=[],
+    )
+
+    rails = LLMRails(config)
+
+    assert getattr(rails, "hook_order") == ["imported", "main"]
+
+
+def test_run_config_py_init_hooks_passes_rails_instance():
+    rails = object()
+    config_module = ModuleType("config")
+
+    def init(received_rails):
+        setattr(config_module, "received_rails", received_rails)
+
+    setattr(config_module, "init", init)
+
+    run_config_py_init_hooks(rails, [config_module])
+
+    assert getattr(config_module, "received_rails") is rails
+
+
+def test_run_config_py_init_hooks_ignores_modules_without_init():
+    rails = object()
+    config_module = ModuleType("config")
+
+    run_config_py_init_hooks(rails, [config_module])

--- a/tests/rails/llm/test_config_validation.py
+++ b/tests/rails/llm/test_config_validation.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.startup import config_validation
+from nemoguardrails.rails.llm.startup.config_validation import validate_llmrails_config
+
+
+def test_config_validation_startup_module_exports_public_helpers():
+    assert config_validation.__all__ == ["validate_llmrails_config"]
+
+
+def test_validate_llmrails_config_delegates_rail_flow_validation(monkeypatch):
+    config = RailsConfig(models=[])
+    calls = []
+
+    def validate_rail_flow_names(config_to_validate):
+        calls.append(config_to_validate)
+
+    monkeypatch.setattr(config_validation, "validate_rail_flow_names", validate_rail_flow_names)
+
+    validate_llmrails_config(config)
+
+    assert calls == [config]
+
+
+def test_validate_llmrails_config_rejects_passthrough_with_single_call():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "passthrough": True,
+            "rails": {"dialog": {"single_call": {"enabled": True}}},
+        }
+    )
+
+    with pytest.raises(InvalidRailsConfigurationError, match="passthrough mode"):
+        validate_llmrails_config(config)

--- a/tests/rails/llm/test_embedding_search.py
+++ b/tests/rails/llm/test_embedding_search.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, Model, RailsConfig
+from nemoguardrails.rails.llm.startup import embedding_search as startup_embedding_search
+from nemoguardrails.rails.llm.startup.embedding_search import (
+    DEFAULT_EMBEDDING_ENGINE,
+    DEFAULT_EMBEDDING_MODEL,
+    EmbeddingSearchState,
+    apply_embedding_model_config,
+    get_embedding_search_provider_instance,
+)
+
+
+def test_embedding_search_startup_module_exports_public_helpers():
+    assert startup_embedding_search.__all__ == [
+        "DEFAULT_EMBEDDING_ENGINE",
+        "DEFAULT_EMBEDDING_MODEL",
+        "EmbeddingSearchState",
+        "apply_embedding_model_config",
+        "get_embedding_search_provider_instance",
+    ]
+
+
+def test_embedding_search_state_owns_providers_defaults_and_provider_creation():
+    class CustomEmbeddingsIndex(EmbeddingsIndex):
+        def __init__(self, prefix: str):
+            self.prefix = prefix
+
+    state = EmbeddingSearchState.default()
+
+    assert state.providers == {}
+    assert state.default_model == DEFAULT_EMBEDDING_MODEL
+    assert state.default_engine == DEFAULT_EMBEDDING_ENGINE
+    assert state.default_params == {}
+
+    state.update_defaults(
+        default_model="prepared-model",
+        default_engine="PreparedEngine",
+        default_params={"device": "cpu"},
+    )
+    state.register_provider("custom", CustomEmbeddingsIndex)
+
+    index = state.get_provider_instance(EmbeddingSearchProvider(name="custom", parameters={"prefix": "docs"}))
+
+    assert isinstance(index, CustomEmbeddingsIndex)
+    assert index.prefix == "docs"
+    assert state.default_model == "prepared-model"
+    assert state.default_engine == "PreparedEngine"
+    assert state.default_params == {"device": "cpu"}
+
+
+def test_apply_embedding_model_config_backfills_default_search_providers():
+    config = RailsConfig(
+        models=[
+            Model(
+                type="embeddings",
+                engine="SentenceTransformers",
+                model="intfloat/e5-large-v2",
+                parameters={"device": "cpu"},
+            )
+        ],
+    )
+
+    default_model, default_engine, default_params = apply_embedding_model_config(
+        config=config,
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+    )
+
+    assert default_model == "intfloat/e5-large-v2"
+    assert default_engine == "SentenceTransformers"
+    assert default_params == {"device": "cpu"}
+    assert config.core.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
+    assert config.core.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
+    assert config.knowledge_base.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
+    assert config.knowledge_base.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
+
+
+def test_get_embedding_search_provider_instance_uses_default_provider_parameters():
+    esp_config = EmbeddingSearchProvider(
+        parameters={
+            "embedding_model": "custom-model",
+            "embedding_engine": "CustomEngine",
+            "embedding_parameters": {"device": "cpu"},
+            "use_batching": True,
+            "max_batch_size": 3,
+            "search_threshold": 0.7,
+        }
+    )
+
+    index = get_embedding_search_provider_instance(
+        embedding_search_providers={},
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+        esp_config=esp_config,
+    )
+
+    assert isinstance(index, BasicEmbeddingsIndex)
+    assert index.embedding_model == "custom-model"
+    assert index.embedding_engine == "CustomEngine"
+    assert index.embedding_params == {"device": "cpu"}
+    assert index.use_batching is True
+    assert index.max_batch_size == 3
+    assert index.search_threshold == 0.7
+
+
+def test_get_embedding_search_provider_instance_uses_registered_custom_provider():
+    class CustomEmbeddingsIndex(EmbeddingsIndex):
+        def __init__(self, prefix: str):
+            self.prefix = prefix
+
+    index = get_embedding_search_provider_instance(
+        embedding_search_providers={"custom": CustomEmbeddingsIndex},
+        default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+        default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+        default_embedding_params={},
+        esp_config=EmbeddingSearchProvider(name="custom", parameters={"prefix": "docs"}),
+    )
+
+    assert isinstance(index, CustomEmbeddingsIndex)
+    assert index.prefix == "docs"
+
+
+def test_get_embedding_search_provider_instance_rejects_unknown_provider():
+    with pytest.raises(Exception, match="Unknown embedding search provider: missing"):
+        get_embedding_search_provider_instance(
+            embedding_search_providers={},
+            default_embedding_model=DEFAULT_EMBEDDING_MODEL,
+            default_embedding_engine=DEFAULT_EMBEDDING_ENGINE,
+            default_embedding_params={},
+            esp_config=EmbeddingSearchProvider(name="missing"),
+        )


### PR DESCRIPTION
## Summary

Moves configuration preparation, `config.py` hooks, Colang resource loading, embedding search defaults, and rail flow validation into startup helpers.

## Why

These responsibilities are part of `LLMRails` construction, but they are independent enough to review before the runtime and generation changes.

## What Changed

- Adds `rails/llm/startup/` helpers for config preparation and validation.
- Extracts built-in Colang 1.0 flow loading and library resource loading.
- Extracts `config.py` module loading and init hook execution.
- Adds focused tests for the startup config helpers.

## Review Notes

The important compatibility question is constructor ordering: default flows, library flows, rail flow marking, config hooks, and validation should happen in the same order as before.

## Stack Position

Part 2 of 8.

- Previous: #20
- Next: #22

## Stack Context

This PR is part of an 8-PR stack that decomposes `LLMRails` internals while keeping `LLMRails` as the public compatibility surface.

Please review each PR against its parent branch, not directly against `develop`, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #20 | `stack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #21 | `stack/llmrails-02-startup-config-colang` | `stack/llmrails-01-public-contract-tests` |
| 3 | #22 | `stack/llmrails-03-startup-models-kb-actions` | `stack/llmrails-02-startup-config-colang` |
| 4 | #23 | `stack/llmrails-04-runtime-conversation` | `stack/llmrails-03-startup-models-kb-actions` |
| 5 | #24 | `stack/llmrails-05-generation-helpers` | `stack/llmrails-04-runtime-conversation` |
| 6 | #25 | `stack/llmrails-06-generation-workflow` | `stack/llmrails-05-generation-helpers` |
| 7 | #26 | `stack/llmrails-07-streaming` | `stack/llmrails-06-generation-workflow` |
| 8 | #27 | `stack/llmrails-08-checks` | `stack/llmrails-07-streaming` |

## Validation

Stack validation run on `stack/llmrails-08-checks`:

```text
poetry run pytest tests/rails/llm tests/test_llmrails_check_async.py tests/test_system_message_conversion.py tests/test_token_usage_integration.py -q
293 passed in 19.21s
```
