### PR TITLE
refactor(llmrails): extract startup model wiring

### DIFF
--- a/nemoguardrails/rails/llm/startup/generation_actions.py
+++ b/nemoguardrails/rails/llm/startup/generation_actions.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM generation action registration."""
+
+from typing import Any, Protocol, Type
+
+from nemoguardrails.actions.llm.generation import LLMGenerationActions
+from nemoguardrails.actions.v2_x.generation import LLMGenerationActionsV2dotx
+
+__all__ = [
+    "GenerationActionRails",
+    "GenerationActionRuntime",
+    "LLMGenerationActions",
+    "LLMGenerationActionsV2dotx",
+    "generation_actions_class_for_colang_version",
+    "register_llm_generation_actions",
+]
+
+
+class GenerationActionRuntime(Protocol):
+    @property
+    def llm_task_manager(self) -> Any: ...
+
+    def register_actions(self, actions_obj: Any, /, override: bool = True) -> None: ...
+
+
+class GenerationActionRails(Protocol):
+    llm_generation_actions: Any
+
+    @property
+    def config(self) -> Any: ...
+
+    @property
+    def llm(self) -> Any: ...
+
+    @property
+    def runtime(self) -> GenerationActionRuntime: ...
+
+    @property
+    def embedding_search(self) -> Any: ...
+
+
+def generation_actions_class_for_colang_version(colang_version: str) -> Type[Any]:
+    """Return the LLM generation actions class selected by the Colang version."""
+    return LLMGenerationActions if colang_version == "1.0" else LLMGenerationActionsV2dotx
+
+
+def register_llm_generation_actions(rails: GenerationActionRails, verbose: bool) -> None:
+    """Create and register the LLM generation actions for an LLMRails instance."""
+    llm_generation_actions_class = generation_actions_class_for_colang_version(rails.config.colang_version)
+    rails.llm_generation_actions = llm_generation_actions_class(
+        config=rails.config,
+        llm=rails.llm,
+        llm_task_manager=rails.runtime.llm_task_manager,
+        get_embedding_search_provider_instance=rails.embedding_search.get_provider_instance,
+        verbose=verbose,
+    )
+
+    rails.runtime.register_actions(rails.llm_generation_actions, override=False)

--- a/nemoguardrails/rails/llm/startup/knowledge_base.py
+++ b/nemoguardrails/rails/llm/startup/knowledge_base.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Knowledge base setup for LLMRails."""
+
+import asyncio
+import threading
+from typing import Callable, Optional
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.kb.kb import KnowledgeBase
+from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
+from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
+from nemoguardrails.utils import get_or_create_event_loop
+
+__all__ = ["build_knowledge_base_for_docs", "init_knowledge_base"]
+
+
+async def build_knowledge_base_for_docs(
+    config: RailsConfig,
+    get_embedding_search_provider_instance: Callable[[Optional[EmbeddingSearchProvider]], EmbeddingsIndex],
+) -> Optional[KnowledgeBase]:
+    """Build the docs-backed knowledge base configured for LLMRails."""
+    if not config.docs:
+        return None
+
+    documents = [doc.content for doc in config.docs]
+    kb = KnowledgeBase(
+        documents=documents,
+        config=config.knowledge_base,
+        get_embedding_search_provider_instance=get_embedding_search_provider_instance,
+    )
+    kb.init()
+    await kb.build()
+    return kb
+
+
+def init_knowledge_base(rails) -> None:
+    """Initialize and register the LLMRails knowledge base."""
+    rails.kb = None
+
+    async def _init_kb():
+        rails.kb = await build_knowledge_base_for_docs(
+            config=rails.config,
+            get_embedding_search_provider_instance=rails.embedding_search.get_provider_instance,
+        )
+
+    # There are still some edge cases not covered by nest_asyncio.
+    # Using a separate thread always for now.
+    loop = get_or_create_event_loop()
+    if True or check_sync_call_from_async_loop():
+        t = threading.Thread(target=asyncio.run, args=(_init_kb(),))
+        t.start()
+        t.join()
+    else:
+        loop.run_until_complete(_init_kb())
+
+    rails.runtime.register_action_param("kb", rails.kb)

--- a/nemoguardrails/rails/llm/startup/llm_action_caches.py
+++ b/nemoguardrails/rails/llm/startup/llm_action_caches.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM action model caches."""
+
+import logging
+from typing import Dict, Protocol
+
+from nemoguardrails.llm.cache import CacheInterface, LFUCache
+from nemoguardrails.rails.llm.config import Model, RailsConfig
+
+log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+
+__all__ = [
+    "build_llm_action_cache",
+    "build_llm_action_caches",
+    "initialize_llm_action_caches",
+]
+
+
+class LLMActionCacheRuntime(Protocol):
+    def register_action_param(self, name: str, value: object) -> None: ...
+
+
+class LLMActionCacheRails(Protocol):
+    @property
+    def config(self) -> RailsConfig: ...
+
+    @property
+    def runtime(self) -> LLMActionCacheRuntime: ...
+
+
+def build_llm_action_cache(model: Model) -> LFUCache:
+    """Build the cache configured for one LLM action model."""
+    if model.cache is None:
+        raise ValueError(f"Missing cache configuration for model '{model.type}'.")
+
+    if model.cache.maxsize <= 0:
+        raise ValueError(
+            f"Invalid cache maxsize for model '{model.type}': {model.cache.maxsize}. "
+            "Capacity must be greater than 0. Skipping cache creation."
+        )
+
+    stats_logging_interval = None
+    if model.cache.stats.enabled and model.cache.stats.log_interval is not None:
+        stats_logging_interval = model.cache.stats.log_interval
+
+    cache = LFUCache(
+        maxsize=model.cache.maxsize,
+        track_stats=model.cache.stats.enabled,
+        stats_logging_interval=stats_logging_interval,
+    )
+
+    log.info(f"Created cache for model '{model.type}' with maxsize {model.cache.maxsize}")
+
+    return cache
+
+
+def build_llm_action_caches(config: RailsConfig) -> Dict[str, CacheInterface]:
+    """Build caches for configured action models."""
+    model_caches: Dict[str, CacheInterface] = dict()
+    for model in config.models:
+        if model.type in ["main", "embeddings"]:
+            continue
+
+        if model.cache and model.cache.enabled:
+            cache = build_llm_action_cache(model)
+            model_caches[model.type] = cache
+
+            log.info(
+                f"Initialized model '{model.type}' with cache %s",
+                "enabled" if cache else "disabled",
+            )
+
+    return model_caches
+
+
+def initialize_llm_action_caches(rails: LLMActionCacheRails) -> None:
+    """Initialize configured action model caches for an LLMRails instance."""
+    model_caches = build_llm_action_caches(rails.config)
+    if model_caches:
+        rails.runtime.register_action_param("model_caches", model_caches)

--- a/nemoguardrails/rails/llm/startup/llm_action_models.py
+++ b/nemoguardrails/rails/llm/startup/llm_action_models.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM action model loading."""
+
+import logging
+import os
+from typing import Any, Callable, Dict, Protocol
+
+from nemoguardrails.exceptions import InvalidModelConfigurationError
+from nemoguardrails.llm.models.initializer import ModelInitializationError
+from nemoguardrails.types import LLMModel
+
+log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+
+InitLLM = Callable[..., LLMModel]
+
+__all__ = [
+    "InitLLM",
+    "LLMActionRails",
+    "LLMActionRuntime",
+    "load_llm_action_models",
+    "model_kwargs_from_config",
+    "sync_update_llm_bindings",
+]
+
+
+class LLMActionRuntime(Protocol):
+    def register_action_param(self, name: str, value: Any) -> None: ...
+
+
+class LLMActionRails(Protocol):
+    llm: Any
+    llm_generation_actions: Any
+
+    @property
+    def config(self) -> Any: ...
+
+    @property
+    def runtime(self) -> LLMActionRuntime: ...
+
+
+def model_kwargs_from_config(model_config: Any) -> Dict[str, Any]:
+    """Prepare model kwargs, including optional API key environment variables."""
+    kwargs = dict(model_config.parameters or {})
+
+    if model_config.api_key_env_var:
+        api_key = os.environ.get(model_config.api_key_env_var)
+        if api_key:
+            kwargs["api_key"] = api_key
+
+    return kwargs
+
+
+def sync_update_llm_bindings(rails: LLMActionRails, llm: LLMModel) -> None:
+    """Synchronize the main LLM bindings after a public update."""
+    rails.llm = llm
+    rails.llm_generation_actions.llm = llm
+    rails.runtime.register_action_param("llm", llm)
+
+
+def load_llm_action_models(rails: LLMActionRails, init_llm: InitLLM) -> None:
+    """Load the main and action LLMs configured for an LLMRails instance."""
+    from nemoguardrails._compat.langchain_kwargs import check_langchain_kwargs
+    from nemoguardrails.llm.frameworks import get_default_framework
+
+    prepare_model_kwargs = getattr(rails, "_prepare_model_kwargs", model_kwargs_from_config)
+    models_to_check = (
+        [model for model in rails.config.models if model.type != "main"] if rails.llm else rails.config.models
+    )
+    check_langchain_kwargs(models_to_check, get_default_framework())
+
+    if rails.llm:
+        if any(model.type == "main" for model in rails.config.models):
+            log.warning(
+                "Both an LLM was provided via constructor and a main LLM is specified in the config. "
+                "The LLM provided via constructor will be used and the main LLM from config will be ignored."
+            )
+        rails.runtime.register_action_param("llm", rails.llm)
+
+    else:
+        main_model = next((model for model in rails.config.models if model.type == "main"), None)
+
+        if main_model and main_model.model:
+            kwargs = prepare_model_kwargs(main_model)
+            rails.llm = init_llm(
+                model_name=main_model.model,
+                provider_name=main_model.engine,
+                mode="chat",
+                kwargs=kwargs,
+            )
+            rails.runtime.register_action_param("llm", rails.llm)
+
+        else:
+            log.info("No main LLM specified in the config and no LLM provided via constructor.")
+
+    llms = dict()
+
+    for llm_config in rails.config.models:
+        if llm_config.type in ["embeddings", "jailbreak_detection"]:
+            continue
+
+        if rails.llm and llm_config.type == "main":
+            continue
+
+        try:
+            model_name = llm_config.model
+            if not model_name:
+                raise InvalidModelConfigurationError(
+                    f"`model` field must be set in model configuration: {llm_config.model_dump_json()}"
+                )
+
+            provider_name = llm_config.engine
+            kwargs = prepare_model_kwargs(llm_config)
+            mode = llm_config.mode
+
+            llm_model = init_llm(
+                model_name=model_name,
+                provider_name=provider_name,
+                mode=mode,
+                kwargs=kwargs,
+            )
+
+            if llm_config.type == "main":
+                if not rails.llm:
+                    rails.llm = llm_model
+                    rails.runtime.register_action_param("llm", rails.llm)
+            else:
+                model_attr = f"{llm_config.type}_llm"
+                if not hasattr(rails, model_attr):
+                    setattr(rails, model_attr, llm_model)
+                rails.runtime.register_action_param(model_attr, getattr(rails, model_attr))
+                llms[llm_config.type] = getattr(rails, model_attr)
+
+        except ModelInitializationError as e:
+            log.error("Failed to initialize model: %s", str(e))
+            raise
+        except Exception as e:
+            log.error("Unexpected error initializing model: %s", str(e))
+            raise
+
+    rails.runtime.register_action_param("llms", llms)

--- a/nemoguardrails/rails/llm/startup/tracing.py
+++ b/nemoguardrails/rails/llm/startup/tracing.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.tracing.adapters.base import InteractionLogAdapter
+
+__all__ = ["create_startup_tracing_adapters"]
+
+
+def create_startup_tracing_adapters(config: RailsConfig) -> list[InteractionLogAdapter] | None:
+    if not config.tracing:
+        return None
+
+    from nemoguardrails.tracing import create_log_adapters
+
+    return create_log_adapters(config.tracing)

--- a/tests/rails/llm/test_generation_actions.py
+++ b/tests/rails/llm/test_generation_actions.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from nemoguardrails.rails.llm.startup import generation_actions
+from nemoguardrails.rails.llm.startup.generation_actions import (
+    generation_actions_class_for_colang_version,
+    register_llm_generation_actions,
+)
+
+
+class RuntimeWithActionRegistration:
+    def __init__(self):
+        self.llm_task_manager = object()
+        self.registered_actions = None
+        self.override = None
+
+    def register_actions(self, actions, override=True):
+        self.registered_actions = actions
+        self.override = override
+
+
+class FakeGenerationActions:
+    def __init__(
+        self,
+        config,
+        llm,
+        llm_task_manager,
+        get_embedding_search_provider_instance,
+        verbose,
+    ):
+        self.config = config
+        self.llm = llm
+        self.llm_task_manager = llm_task_manager
+        self.get_embedding_search_provider_instance = get_embedding_search_provider_instance
+        self.verbose = verbose
+
+
+class FakeGenerationActionsV2(FakeGenerationActions):
+    pass
+
+
+class FakeRails:
+    def __init__(self, config, llm, runtime, get_embedding_search_provider_instance):
+        self.config = config
+        self.llm = llm
+        self.runtime = runtime
+        self.embedding_search = SimpleNamespace(get_provider_instance=get_embedding_search_provider_instance)
+        self.llm_generation_actions = None
+
+
+def test_generation_actions_class_for_colang_version_uses_v1_actions(monkeypatch):
+    monkeypatch.setattr(generation_actions, "LLMGenerationActions", FakeGenerationActions)
+
+    actions_class = generation_actions_class_for_colang_version("1.0")
+
+    assert actions_class is FakeGenerationActions
+
+
+def test_generation_actions_class_for_colang_version_uses_v2_actions(monkeypatch):
+    monkeypatch.setattr(generation_actions, "LLMGenerationActionsV2dotx", FakeGenerationActionsV2)
+
+    actions_class = generation_actions_class_for_colang_version("2.x")
+
+    assert actions_class is FakeGenerationActionsV2
+
+
+def test_register_llm_generation_actions_registers_without_overriding(monkeypatch):
+    monkeypatch.setattr(generation_actions, "LLMGenerationActions", FakeGenerationActions)
+    config = SimpleNamespace(colang_version="1.0")
+    llm = object()
+    runtime = RuntimeWithActionRegistration()
+
+    def get_embedding_search_provider_instance(esp_config=None):
+        del esp_config
+        return None
+
+    rails = FakeRails(
+        config=config,
+        llm=llm,
+        runtime=runtime,
+        get_embedding_search_provider_instance=get_embedding_search_provider_instance,
+    )
+
+    register_llm_generation_actions(rails, verbose=True)
+
+    assert isinstance(rails.llm_generation_actions, FakeGenerationActions)
+    assert rails.llm_generation_actions.config is config
+    assert rails.llm_generation_actions.llm is llm
+    assert rails.llm_generation_actions.llm_task_manager is runtime.llm_task_manager
+    assert rails.llm_generation_actions.get_embedding_search_provider_instance is get_embedding_search_provider_instance
+    assert rails.llm_generation_actions.verbose is True
+    assert runtime.registered_actions is rails.llm_generation_actions
+    assert runtime.override is False

--- a/tests/rails/llm/test_knowledge_base.py
+++ b/tests/rails/llm/test_knowledge_base.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.rails.llm.config import Document, RailsConfig
+from nemoguardrails.rails.llm.startup import knowledge_base
+from nemoguardrails.rails.llm.startup.knowledge_base import (
+    build_knowledge_base_for_docs,
+    init_knowledge_base,
+)
+
+
+class RuntimeWithActionParams:
+    def __init__(self):
+        self.registered_action_params = {}
+
+    def register_action_param(self, name, value):
+        self.registered_action_params[name] = value
+
+
+@pytest.mark.asyncio
+async def test_build_knowledge_base_for_docs_returns_none_without_docs(monkeypatch):
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("KnowledgeBase should not be constructed without docs.")
+
+    monkeypatch.setattr(knowledge_base, "KnowledgeBase", fail_if_constructed)
+
+    kb = await build_knowledge_base_for_docs(
+        config=RailsConfig(models=[]),
+        get_embedding_search_provider_instance=lambda _: cast(EmbeddingsIndex, None),
+    )
+
+    assert kb is None
+
+
+@pytest.mark.asyncio
+async def test_build_knowledge_base_for_docs_builds_docs_backed_kb(monkeypatch):
+    provider = cast(EmbeddingsIndex, object())
+    created = {}
+
+    class FakeKnowledgeBase:
+        def __init__(self, documents, config, get_embedding_search_provider_instance):
+            self.documents = documents
+            self.config = config
+            self.get_embedding_search_provider_instance = get_embedding_search_provider_instance
+            self.init_called = False
+            self.build_called = False
+            created["kb"] = self
+
+        def init(self):
+            self.init_called = True
+
+        async def build(self):
+            self.build_called = True
+
+    monkeypatch.setattr(knowledge_base, "KnowledgeBase", FakeKnowledgeBase)
+    config = RailsConfig(
+        models=[],
+        docs=[
+            Document(format="md", content="# Alpha\n\nA"),
+            Document(format="md", content="# Beta\n\nB"),
+        ],
+    )
+
+    kb = cast(
+        Any,
+        await build_knowledge_base_for_docs(
+            config=config,
+            get_embedding_search_provider_instance=lambda _: provider,
+        ),
+    )
+
+    assert kb is created["kb"]
+    assert kb.documents == ["# Alpha\n\nA", "# Beta\n\nB"]
+    assert kb.config is config.knowledge_base
+    assert kb.get_embedding_search_provider_instance(None) is provider
+    assert kb.init_called is True
+    assert kb.build_called is True
+
+
+def test_init_knowledge_base_uses_thread_path_and_registers_kb(monkeypatch):
+    built_kb = object()
+    calls = {"thread_started": False, "thread_joined": False}
+
+    async def fake_build_knowledge_base_for_docs(config, get_embedding_search_provider_instance):
+        assert rails.kb is None
+        assert config is rails.config
+        assert get_embedding_search_provider_instance is get_provider_instance
+        return built_kb
+
+    class FakeThread:
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+
+        def start(self):
+            calls["thread_started"] = True
+            self.target(*self.args)
+
+        def join(self):
+            calls["thread_joined"] = True
+
+    def get_provider_instance(_=None):
+        return None
+
+    rails = SimpleNamespace(
+        config=RailsConfig(
+            models=[],
+            docs=[Document(format="md", content="# Alpha\n\nA")],
+        ),
+        kb="existing",
+        runtime=RuntimeWithActionParams(),
+        embedding_search=SimpleNamespace(get_provider_instance=get_provider_instance),
+    )
+    monkeypatch.setattr(
+        knowledge_base,
+        "build_knowledge_base_for_docs",
+        fake_build_knowledge_base_for_docs,
+    )
+    monkeypatch.setattr(knowledge_base.threading, "Thread", FakeThread)
+    monkeypatch.setattr(knowledge_base, "get_or_create_event_loop", lambda: object())
+
+    init_knowledge_base(rails)
+
+    assert rails.kb is built_kb
+    assert rails.runtime.registered_action_params["kb"] is built_kb
+    assert calls == {"thread_started": True, "thread_joined": True}

--- a/tests/rails/llm/test_llm_action_caches.py
+++ b/tests/rails/llm/test_llm_action_caches.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.rails.llm.config import (
+    CacheStatsConfig,
+    Model,
+    ModelCacheConfig,
+    RailsConfig,
+)
+from nemoguardrails.rails.llm.startup.llm_action_caches import (
+    build_llm_action_cache,
+    build_llm_action_caches,
+)
+
+
+def test_build_llm_action_caches_skips_main_embeddings_and_disabled_caches():
+    config = RailsConfig(
+        models=[
+            Model(
+                type="main",
+                engine="fake",
+                model="fake",
+                cache=ModelCacheConfig(enabled=True),
+            ),
+            Model(
+                type="embeddings",
+                engine="fake",
+                model="fake",
+                cache=ModelCacheConfig(enabled=True),
+            ),
+            Model(
+                type="content_safety",
+                engine="fake",
+                model="fake",
+                cache=ModelCacheConfig(enabled=False),
+            ),
+        ]
+    )
+
+    assert build_llm_action_caches(config) == {}
+
+
+def test_build_llm_action_caches_creates_enabled_action_model_caches():
+    config = RailsConfig(
+        models=[
+            Model(
+                type="content_safety",
+                engine="fake",
+                model="fake",
+                cache=ModelCacheConfig(enabled=True, maxsize=1000),
+            ),
+            Model(
+                type="jailbreak_detection",
+                engine="fake",
+                model="fake",
+                cache=ModelCacheConfig(enabled=True, maxsize=2000),
+            ),
+        ]
+    )
+
+    model_caches = build_llm_action_caches(config)
+
+    assert set(model_caches.keys()) == {"content_safety", "jailbreak_detection"}
+    assert model_caches["content_safety"].maxsize == 1000
+    assert model_caches["jailbreak_detection"].maxsize == 2000
+
+
+def test_build_llm_action_cache_preserves_stats_config():
+    model = Model(
+        type="content_safety",
+        engine="fake",
+        model="fake",
+        cache=ModelCacheConfig(
+            enabled=True,
+            maxsize=5000,
+            stats=CacheStatsConfig(enabled=True, log_interval=60.0),
+        ),
+    )
+
+    cache = build_llm_action_cache(model)
+
+    assert cache.maxsize == 5000
+    assert cache.track_stats is True
+    assert cache.stats_logging_interval == 60.0
+    assert cache.supports_stats_logging() is True
+
+
+def test_build_llm_action_cache_rejects_invalid_maxsize():
+    model = Model(
+        type="content_safety",
+        engine="fake",
+        model="fake",
+        cache=ModelCacheConfig(enabled=True, maxsize=0),
+    )
+
+    with pytest.raises(ValueError, match="Invalid cache maxsize"):
+        build_llm_action_cache(model)

--- a/tests/rails/llm/test_llm_action_models.py
+++ b/tests/rails/llm/test_llm_action_models.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+from nemoguardrails.rails.llm.config import Model, RailsConfig
+from nemoguardrails.rails.llm.startup.llm_action_models import (
+    load_llm_action_models,
+    model_kwargs_from_config,
+    sync_update_llm_bindings,
+)
+from nemoguardrails.types import LLMModel
+
+
+class RuntimeWithActionParams:
+    def __init__(self):
+        self.registered_action_params = {}
+
+    def register_action_param(self, name, value):
+        self.registered_action_params[name] = value
+
+
+class FakeRails:
+    content_safety_llm: Any
+
+    def __init__(self, config: RailsConfig, llm: Any, runtime: RuntimeWithActionParams):
+        self.config = config
+        self.llm = llm
+        self.runtime = runtime
+        self.llm_generation_actions = MagicMock()
+
+
+def test_model_kwargs_from_config_adds_api_key_from_environment():
+    model = Model(
+        type="main",
+        engine="openai",
+        model="gpt-3.5-turbo",
+        api_key_env_var="TEST_OPENAI_KEY",
+        parameters={"temperature": 0.7},
+    )
+
+    with patch.dict("os.environ", {"TEST_OPENAI_KEY": "secret-api-key-from-env"}):
+        kwargs = model_kwargs_from_config(model)
+
+    assert kwargs["api_key"] == "secret-api-key-from-env"
+    assert kwargs["temperature"] == 0.7
+
+
+def test_model_kwargs_from_config_omits_missing_api_key_environment_variable():
+    model = Model(
+        type="main",
+        engine="openai",
+        model="gpt-3.5-turbo",
+        api_key_env_var="MISSING_OPENAI_KEY",
+        parameters={"temperature": 0.5},
+    )
+
+    with patch.dict("os.environ", {}, clear=True):
+        kwargs = model_kwargs_from_config(model)
+
+    assert "api_key" not in kwargs
+    assert kwargs["temperature"] == 0.5
+
+
+def test_model_kwargs_from_config_preserves_direct_api_key_parameter():
+    model = Model(
+        type="main",
+        engine="openai",
+        model="gpt-3.5-turbo",
+        parameters={"api_key": "direct-key", "temperature": 0.3},
+    )
+
+    kwargs = model_kwargs_from_config(model)
+
+    assert kwargs["api_key"] == "direct-key"
+    assert kwargs["temperature"] == 0.3
+
+
+def test_load_llm_action_models_uses_constructor_llm_and_loads_action_models():
+    injected_llm = object()
+    content_safety_llm = object()
+    init_llm = MagicMock(return_value=content_safety_llm)
+    rails = FakeRails(
+        config=RailsConfig(
+            models=[
+                Model(type="main", engine="fake", model="main-model"),
+                Model(type="content_safety", engine="fake", model="content-safety-model"),
+            ]
+        ),
+        llm=injected_llm,
+        runtime=RuntimeWithActionParams(),
+    )
+
+    load_llm_action_models(rails, init_llm=init_llm)
+
+    init_llm.assert_called_once_with(
+        model_name="content-safety-model",
+        provider_name="fake",
+        mode="chat",
+        kwargs={},
+    )
+    assert rails.llm is injected_llm
+    assert rails.content_safety_llm is content_safety_llm
+    assert rails.runtime.registered_action_params["llm"] is injected_llm
+    assert rails.runtime.registered_action_params["content_safety_llm"] is content_safety_llm
+    assert rails.runtime.registered_action_params["llms"] == {"content_safety": content_safety_llm}
+
+
+def test_load_llm_action_models_initializes_main_llm_from_config():
+    main_llm = object()
+    init_llm = MagicMock(return_value=main_llm)
+    rails = FakeRails(
+        config=RailsConfig(
+            models=[
+                Model(
+                    type="main",
+                    engine="fake",
+                    model="main-model",
+                    parameters={"temperature": 0.2},
+                )
+            ]
+        ),
+        llm=None,
+        runtime=RuntimeWithActionParams(),
+    )
+
+    load_llm_action_models(rails, init_llm=init_llm)
+
+    init_llm.assert_called_once_with(
+        model_name="main-model",
+        provider_name="fake",
+        mode="chat",
+        kwargs={"temperature": 0.2},
+    )
+    assert rails.llm is main_llm
+    assert rails.runtime.registered_action_params["llm"] is main_llm
+    assert rails.runtime.registered_action_params["llms"] == {}
+
+
+def test_sync_update_llm_bindings_updates_llm_generation_actions_and_runtime_param():
+    initial_llm = cast(LLMModel, object())
+    updated_llm = cast(LLMModel, object())
+    rails = FakeRails(
+        config=RailsConfig(models=[]),
+        llm=initial_llm,
+        runtime=RuntimeWithActionParams(),
+    )
+
+    sync_update_llm_bindings(rails, updated_llm)
+
+    assert rails.llm is updated_llm
+    assert rails.llm_generation_actions.llm is updated_llm
+    assert rails.runtime.registered_action_params["llm"] is updated_llm


### PR DESCRIPTION
## Summary

Moves LLM and action model setup, action caches, generation action registration, knowledge base setup, and tracing adapter creation into startup helpers.

## Why

This keeps constructor-side model and action wiring reviewable separately from Colang runtime execution and generation behavior.

## What Changed

- Extracts LLM/action model initialization helpers.
- Extracts model cache construction and registration.
- Extracts generation action registration.
- Extracts knowledge base setup.
- Extracts startup tracing adapter creation.
- Adds focused tests for each startup helper.

## Review Notes

The key review point is whether `LLMRails.__init__` still exposes and registers the same runtime dependencies in the same effective order.

## Stack Position

Part 3 of 8.

- Previous: #21
- Next: #23

## Stack Context

This PR is part of an 8-PR stack that decomposes `LLMRails` internals while keeping `LLMRails` as the public compatibility surface.

Please review each PR against its parent branch, not directly against `develop`, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #20 | `stack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #21 | `stack/llmrails-02-startup-config-colang` | `stack/llmrails-01-public-contract-tests` |
| 3 | #22 | `stack/llmrails-03-startup-models-kb-actions` | `stack/llmrails-02-startup-config-colang` |
| 4 | #23 | `stack/llmrails-04-runtime-conversation` | `stack/llmrails-03-startup-models-kb-actions` |
| 5 | #24 | `stack/llmrails-05-generation-helpers` | `stack/llmrails-04-runtime-conversation` |
| 6 | #25 | `stack/llmrails-06-generation-workflow` | `stack/llmrails-05-generation-helpers` |
| 7 | #26 | `stack/llmrails-07-streaming` | `stack/llmrails-06-generation-workflow` |
| 8 | #27 | `stack/llmrails-08-checks` | `stack/llmrails-07-streaming` |

## Validation

Stack validation run on `stack/llmrails-08-checks`:

```text
poetry run pytest tests/rails/llm tests/test_llmrails_check_async.py tests/test_system_message_conversion.py tests/test_token_usage_integration.py -q
293 passed in 19.21s
```
