### PR TITLE
refactor(llmrails): extract runtime and conversation helpers

### DIFF
--- a/nemoguardrails/rails/llm/conversation/__init__.py
+++ b/nemoguardrails/rails/llm/conversation/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []

--- a/nemoguardrails/rails/llm/conversation/conversation_events.py
+++ b/nemoguardrails/rails/llm/conversation/conversation_events.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conversation message conversion to Colang events."""
+
+from collections.abc import MutableMapping
+from typing import Any, List, Protocol
+
+from nemoguardrails.colang.v2_x.runtime.flows import Action
+from nemoguardrails.rails.llm.utils import get_history_cache_key
+from nemoguardrails.utils import new_event_dict, new_uuid
+
+__all__ = [
+    "ConversationEventRails",
+    "events_for_messages",
+    "events_history_cache_prefix",
+    "store_events_history_cache_entry",
+]
+
+
+class ConversationEventRails(Protocol):
+    @property
+    def config(self) -> Any: ...
+
+    @property
+    def events_history_cache(self) -> MutableMapping[str, list[dict]]: ...
+
+
+def events_history_cache_prefix(
+    events_history_cache: MutableMapping[str, list[dict]],
+    messages: List[dict],
+) -> tuple[int, list[dict]]:
+    """Return the longest cached event prefix for the provided messages."""
+    p = len(messages) - 1
+    while p > 0:
+        cache_key = get_history_cache_key(messages[0:p])
+        if cache_key in events_history_cache:
+            return p, events_history_cache[cache_key].copy()
+
+        p -= 1
+
+    return 0, []
+
+
+def store_events_history_cache_entry(
+    events_history_cache: MutableMapping[str, list[dict]],
+    messages: List[dict],
+    events: list[dict],
+) -> None:
+    """Store events for a complete v1 message history cache key."""
+    cache_key = get_history_cache_key(messages)
+    events_history_cache[cache_key] = events
+
+
+def events_for_messages(rails: ConversationEventRails, messages: List[dict], state: Any):
+    """Return Colang events corresponding to OpenAI-style messages."""
+    events = []
+
+    if rails.config.colang_version == "1.0":
+        p, events = events_history_cache_prefix(rails.events_history_cache, messages)
+
+        for idx in range(p, len(messages)):
+            msg = messages[idx]
+            if msg["role"] == "user":
+                events.append(
+                    {
+                        "type": "UtteranceUserActionFinished",
+                        "final_transcript": msg["content"],
+                    }
+                )
+
+                if idx != len(messages) - 1:
+                    events.append(
+                        {
+                            "type": "UserMessage",
+                            "text": msg["content"],
+                        }
+                    )
+
+            elif msg["role"] == "assistant":
+                if msg.get("tool_calls"):
+                    events.append({"type": "BotToolCalls", "tool_calls": msg["tool_calls"]})
+                else:
+                    action_uid = new_uuid()
+                    start_event = new_event_dict(
+                        "StartUtteranceBotAction",
+                        script=msg["content"],
+                        action_uid=action_uid,
+                    )
+                    finished_event = new_event_dict(
+                        "UtteranceBotActionFinished",
+                        final_script=msg["content"],
+                        is_success=True,
+                        action_uid=action_uid,
+                    )
+                    events.extend([start_event, finished_event])
+            elif msg["role"] == "context":
+                events.append({"type": "ContextUpdate", "data": msg["content"]})
+            elif msg["role"] == "event":
+                events.append(msg["event"])
+            elif msg["role"] == "system":
+                events.append({"type": "SystemMessage", "content": msg["content"]})
+            elif msg["role"] == "tool":
+                if idx == len(messages) - 1:
+                    user_message = None
+                    for prev_msg in reversed(messages[:idx]):
+                        if prev_msg["role"] == "user":
+                            user_message = prev_msg["content"]
+                            break
+
+                    if user_message:
+                        if rails.config.rails.tool_input.flows:
+                            tool_messages = []
+                            for tool_idx in range(len(messages)):
+                                if messages[tool_idx]["role"] == "tool":
+                                    tool_messages.append(
+                                        {
+                                            "content": messages[tool_idx]["content"],
+                                            "name": messages[tool_idx].get("name", "unknown"),
+                                            "tool_call_id": messages[tool_idx].get("tool_call_id", ""),
+                                        }
+                                    )
+
+                            events.append(
+                                {
+                                    "type": "UserToolMessages",
+                                    "tool_messages": tool_messages,
+                                }
+                            )
+
+                        else:
+                            events.append({"type": "UserMessage", "text": user_message})
+
+    else:
+        for idx in range(len(messages)):
+            msg = messages[idx]
+            if msg["role"] == "user":
+                events.append(
+                    {
+                        "type": "UtteranceUserActionFinished",
+                        "final_transcript": msg["content"],
+                    }
+                )
+
+            elif msg["role"] == "assistant":
+                raise ValueError(
+                    "Providing `assistant` messages as input is not supported for Colang 2.0 configurations."
+                )
+            elif msg["role"] == "context":
+                events.append({"type": "ContextUpdate", "data": msg["content"]})
+            elif msg["role"] == "event":
+                events.append(msg["event"])
+            elif msg["role"] == "system":
+                events.append({"type": "SystemMessage", "content": msg["content"]})
+            elif msg["role"] == "tool":
+                action_uid = msg["tool_call_id"]
+                return_value = msg["content"]
+                action: Action = state.actions[action_uid]
+                events.append(
+                    new_event_dict(
+                        f"{action.name}Finished",
+                        action_uid=action_uid,
+                        action_name=action.name,
+                        status="success",
+                        is_success=True,
+                        return_value=return_value,
+                        events=[],
+                    )
+                )
+
+    return events

--- a/nemoguardrails/rails/llm/runtime/__init__.py
+++ b/nemoguardrails/rails/llm/runtime/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []

--- a/nemoguardrails/rails/llm/runtime/colang_runtime.py
+++ b/nemoguardrails/rails/llm/runtime/colang_runtime.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Colang runtime selection."""
+
+from typing import Dict, Type
+
+from nemoguardrails.colang.v1_0.runtime.runtime import Runtime, RuntimeV1_0
+from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.rails.llm.config import RailsConfig
+
+__all__ = ["runtime_for_colang_version"]
+
+
+def runtime_for_colang_version(config: RailsConfig, verbose: bool) -> Runtime:
+    """Create the Colang runtime selected by the config version."""
+    colang_version_to_runtime: Dict[str, Type[Runtime]] = {
+        "1.0": RuntimeV1_0,
+        "2.x": RuntimeV2_x,
+    }
+    if config.colang_version not in colang_version_to_runtime:
+        raise InvalidRailsConfigurationError(
+            f"Unsupported colang version: {config.colang_version}. "
+            f"Supported versions: {list(colang_version_to_runtime.keys())}"
+        )
+
+    return colang_version_to_runtime[config.colang_version](config=config, verbose=verbose)

--- a/nemoguardrails/rails/llm/runtime/colang_turns.py
+++ b/nemoguardrails/rails/llm/runtime/colang_turns.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Colang runtime turn execution helpers."""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, List, Optional, Protocol, Tuple, Union, cast
+
+from nemoguardrails.actions.llm.utils import get_colang_history
+from nemoguardrails.colang.v2_x.runtime.flows import State
+from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
+from nemoguardrails.colang.v2_x.runtime.serialization import state_to_json
+from nemoguardrails.context import llm_stats_var, streaming_handler_var
+from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.streaming import END_OF_STREAM
+from nemoguardrails.utils import extract_error_json
+
+log = logging.getLogger(__name__)
+
+process_events_semaphore = asyncio.Semaphore(1)
+
+__all__ = [
+    "ColangTurnRails",
+    "ColangTurnResult",
+    "generate_colang_events",
+    "process_colang_events",
+    "process_events_semaphore",
+    "run_colang_turn",
+]
+
+
+@dataclass
+class ColangTurnResult:
+    new_events: List[dict]
+    output_state: Optional[dict]
+
+
+class ColangTurnRails(Protocol):
+    @property
+    def config(self) -> Any: ...
+
+    @property
+    def runtime(self) -> Any: ...
+
+    @property
+    def verbose(self) -> bool: ...
+
+
+async def run_colang_turn(
+    rails: ColangTurnRails,
+    events: List[dict],
+    state: Any,
+    processing_log: List[dict],
+) -> ColangTurnResult:
+    """Run one Colang turn for events already converted from messages."""
+    if rails.config.colang_version == "1.0":
+        return await _run_colang_1_turn(rails, events, state, processing_log)
+    return await _run_colang_2_turn(rails, events, state)
+
+
+async def _run_colang_1_turn(
+    rails: ColangTurnRails,
+    events: List[dict],
+    state: Any,
+    processing_log: List[dict],
+) -> ColangTurnResult:
+    # If we had a state object, we also need to prepend the events from the state.
+    state_events = []
+    if state:
+        assert isinstance(state, dict)
+        state_events = state["events"]
+
+    try:
+        new_events = await rails.runtime.generate_events(
+            state_events + events,
+            processing_log=processing_log,
+        )
+        return ColangTurnResult(new_events=new_events, output_state=None)
+    except Exception as e:
+        log.error("Error in generate_async: %s", e, exc_info=True)
+        streaming_handler = streaming_handler_var.get()
+        if streaming_handler:
+            # Push an error chunk instead of None.
+            error_message = str(e)
+            error_dict = extract_error_json(error_message)
+            error_payload: str = json.dumps(error_dict)
+            await streaming_handler.push_chunk(error_payload)
+            # push a termination signal
+            await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
+        # Re-raise the exact exception
+        raise
+
+
+async def _run_colang_2_turn(
+    rails: ColangTurnRails,
+    events: List[dict],
+    state: Any,
+) -> ColangTurnResult:
+    # In generation mode, by default the bot response is an instant action.
+    instant_actions = ["UtteranceBotAction"]
+    if rails.config.rails.actions.instant_actions is not None:
+        instant_actions = rails.config.rails.actions.instant_actions
+
+    # Cast this explicitly to avoid certain warnings
+    runtime: RuntimeV2_x = cast(RuntimeV2_x, rails.runtime)
+
+    # Compute the new events. In generation mode, the processing is always
+    # blocking, i.e., it waits for all local actions (sync and async).
+    new_events, output_state = await runtime.process_events(
+        events,
+        state=state,
+        instant_actions=instant_actions,
+        blocking=True,
+    )
+
+    return ColangTurnResult(
+        new_events=new_events,
+        output_state={"state": state_to_json(output_state), "version": "2.x"},
+    )
+
+
+async def generate_colang_events(rails: ColangTurnRails, events: List[dict]) -> List[dict]:
+    """Generate the next Colang 1.0 events for an event history."""
+    t0 = time.time()
+
+    # Initialize the LLM stats
+    llm_stats = LLMStats()
+    llm_stats_var.set(llm_stats)
+
+    # Compute the new events.
+    processing_log = []
+    new_events = await rails.runtime.generate_events(events, processing_log=processing_log)
+
+    # If logging is enabled, we log the conversation
+    # TODO: add support for logging flag
+    if rails.verbose:
+        history = get_colang_history(events)
+        log.info(f"Conversation history so far: \n{history}")
+
+    log.info("--- :: Total processing took %.2f seconds." % (time.time() - t0))
+    log.info("--- :: Stats: %s" % llm_stats)
+
+    return new_events
+
+
+async def process_colang_events(
+    rails: ColangTurnRails,
+    events: List[dict],
+    state: Union[Optional[dict], State] = None,
+    blocking: bool = False,
+    semaphore: Optional[asyncio.Semaphore] = None,
+) -> Tuple[List[dict], Union[dict, State]]:
+    """Process Colang events in order and return output events plus state."""
+    t0 = time.time()
+    llm_stats = LLMStats()
+    llm_stats_var.set(llm_stats)
+
+    # Compute the new events.
+    # We need to protect 'process_events' to be called only once at a time
+    # TODO (cschueller): Why is this?
+    event_semaphore = semaphore or process_events_semaphore
+    async with event_semaphore:
+        output_events, output_state = await rails.runtime.process_events(events, state, blocking)
+
+    took = time.time() - t0
+    # Small tweak, disable this when there were no events (or it was just too fast).
+    if took > 0.1:
+        log.info("--- :: Total processing took %.2f seconds." % took)
+        log.info("--- :: Stats: %s" % llm_stats)
+
+    return output_events, output_state

--- a/tests/rails/llm/test_colang_runtime.py
+++ b/tests/rails/llm/test_colang_runtime.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.colang.v1_0.runtime.runtime import RuntimeV1_0
+from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.rails.llm import runtime as runtime_package
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.llmrails import LLMRails
+from nemoguardrails.rails.llm.runtime import colang_runtime
+from nemoguardrails.rails.llm.runtime.colang_runtime import runtime_for_colang_version
+
+
+def test_runtime_package_has_no_star_exports():
+    assert runtime_package.__all__ == []
+
+
+def test_runtime_for_colang_version_uses_v1_runtime():
+    config = RailsConfig(models=[], colang_version="1.0")
+
+    runtime = runtime_for_colang_version(config=config, verbose=False)
+
+    assert isinstance(runtime, RuntimeV1_0)
+
+
+def test_runtime_for_colang_version_uses_v2_runtime():
+    config = RailsConfig(models=[], colang_version="2.x")
+
+    runtime = runtime_for_colang_version(config=config, verbose=True)
+
+    assert isinstance(runtime, RuntimeV2_x)
+
+
+def test_runtime_for_colang_version_rejects_unsupported_version():
+    config = RailsConfig(models=[], colang_version="3.x")
+
+    with pytest.raises(InvalidRailsConfigurationError) as exc_info:
+        runtime_for_colang_version(config=config, verbose=False)
+
+    assert str(exc_info.value) == "Unsupported colang version: 3.x. Supported versions: ['1.0', '2.x']"
+
+
+def test_colang_runtime_module_exports_public_helpers():
+    assert colang_runtime.__all__ == ["runtime_for_colang_version"]
+
+
+def test_llmrails_initializes_v1_runtime():
+    rails = LLMRails(RailsConfig(models=[], colang_version="1.0"))
+
+    assert isinstance(rails.runtime, RuntimeV1_0)
+
+
+def test_llmrails_initializes_v2_runtime():
+    rails = LLMRails(RailsConfig(models=[], colang_version="2.x"))
+
+    assert isinstance(rails.runtime, RuntimeV2_x)
+
+
+def test_llmrails_rejects_unsupported_runtime_version():
+    config = RailsConfig(models=[], colang_version="3.x")
+
+    with pytest.raises(InvalidRailsConfigurationError) as exc_info:
+        LLMRails(config)
+
+    assert str(exc_info.value) == "Unsupported colang version: 3.x. Supported versions: ['1.0', '2.x']"
+
+
+def test_config_py_init_hook_sees_initialized_runtime(tmp_path):
+    config_path = tmp_path / "config"
+    config_path.mkdir()
+    (config_path / "config.py").write_text(
+        "def init(app):\n    app.runtime_seen_by_init = type(app.runtime).__name__\n"
+    )
+    config = RailsConfig(
+        config_path=str(config_path),
+        models=[],
+    )
+
+    rails = LLMRails(config)
+
+    assert getattr(rails, "runtime_seen_by_init") == "RuntimeV1_0"

--- a/tests/rails/llm/test_colang_turns.py
+++ b/tests/rails/llm/test_colang_turns.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from nemoguardrails.context import llm_stats_var, streaming_handler_var
+from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.rails.llm import llmrails as llmrails_module
+from nemoguardrails.rails.llm.llmrails import LLMRails
+from nemoguardrails.rails.llm.runtime import colang_turns
+from nemoguardrails.rails.llm.runtime.colang_turns import (
+    generate_colang_events,
+    process_colang_events,
+    run_colang_turn,
+)
+from nemoguardrails.streaming import END_OF_STREAM
+
+
+class FakeRails:
+    def __init__(self, colang_version: str, runtime, instant_actions=None):
+        self.config = SimpleNamespace(
+            colang_version=colang_version,
+            rails=SimpleNamespace(
+                actions=SimpleNamespace(instant_actions=instant_actions),
+            ),
+        )
+        self.runtime = runtime
+        self.verbose = False
+
+
+def make_rails(colang_version: str, runtime, instant_actions=None):
+    return FakeRails(colang_version=colang_version, runtime=runtime, instant_actions=instant_actions)
+
+
+@pytest.mark.asyncio
+async def test_generate_colang_events_sets_stats_and_passes_processing_log():
+    class Runtime:
+        def __init__(self):
+            self.processing_log = None
+
+        async def generate_events(self, events, processing_log):
+            self.processing_log = processing_log
+            processing_log.append({"event": "generated"})
+            return [{"type": "BotIntent", "intent": "express greeting"}]
+
+    runtime = Runtime()
+    new_events = await generate_colang_events(
+        make_rails("1.0", runtime),
+        events=[{"type": "UserMessage", "text": "Hi"}],
+    )
+
+    assert new_events == [{"type": "BotIntent", "intent": "express greeting"}]
+    assert runtime.processing_log == [{"event": "generated"}]
+    assert isinstance(llm_stats_var.get(), LLMStats)
+
+
+@pytest.mark.asyncio
+async def test_process_colang_events_sets_stats_and_forwards_state_and_blocking():
+    class Runtime:
+        def __init__(self):
+            self.calls = []
+
+        async def process_events(self, events, state, blocking):
+            self.calls.append((events, state, blocking))
+            return [{"type": "OutputEvent"}], {"state": "updated"}
+
+    runtime = Runtime()
+    output_events, output_state = await process_colang_events(
+        make_rails("2.x", runtime),
+        events=[{"type": "InputEvent"}],
+        state={"state": "input"},
+        blocking=True,
+    )
+
+    assert runtime.calls == [([{"type": "InputEvent"}], {"state": "input"}, True)]
+    assert output_events == [{"type": "OutputEvent"}]
+    assert output_state == {"state": "updated"}
+    assert isinstance(llm_stats_var.get(), LLMStats)
+
+
+@pytest.mark.asyncio
+async def test_process_colang_events_serializes_runtime_calls():
+    class Runtime:
+        def __init__(self):
+            self.active_calls = 0
+            self.max_active_calls = 0
+
+        async def process_events(self, events, state, blocking):
+            self.active_calls += 1
+            self.max_active_calls = max(self.max_active_calls, self.active_calls)
+            await asyncio.sleep(0)
+            self.active_calls -= 1
+            return events, state
+
+    runtime = Runtime()
+    rails = make_rails("2.x", runtime)
+
+    await asyncio.gather(
+        process_colang_events(rails, [{"type": "First"}]),
+        process_colang_events(rails, [{"type": "Second"}]),
+    )
+
+    assert runtime.max_active_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_llmrails_process_events_uses_module_semaphore_patch_point():
+    class Runtime:
+        def __init__(self):
+            self.calls = 0
+
+        async def process_events(self, events, state, blocking):
+            self.calls += 1
+            return events, state
+
+    runtime = Runtime()
+    rails = cast(Any, object.__new__(LLMRails))
+    rails.runtime = runtime
+
+    original_semaphore = llmrails_module.process_events_semaphore
+    llmrails_module.process_events_semaphore = asyncio.Semaphore(0)
+    try:
+        task = asyncio.create_task(rails.process_events_async([{"type": "InputEvent"}]))
+        await asyncio.sleep(0)
+        assert runtime.calls == 0
+
+        llmrails_module.process_events_semaphore.release()
+        await task
+    finally:
+        llmrails_module.process_events_semaphore = original_semaphore
+
+    assert runtime.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_run_colang_turn_v1_prepends_state_events_and_passes_processing_log():
+    class Runtime:
+        def __init__(self):
+            self.calls = []
+
+        async def generate_events(self, events, processing_log):
+            self.calls.append((events, processing_log))
+            processing_log.append({"event": "logged"})
+            return [{"type": "BotIntent", "intent": "express greeting"}]
+
+    runtime = Runtime()
+    processing_log = []
+    turn_result = await run_colang_turn(
+        make_rails("1.0", runtime),
+        events=[{"type": "UserMessage", "text": "Hi"}],
+        state={"events": [{"type": "CachedEvent"}]},
+        processing_log=processing_log,
+    )
+
+    assert runtime.calls == [
+        (
+            [
+                {"type": "CachedEvent"},
+                {"type": "UserMessage", "text": "Hi"},
+            ],
+            processing_log,
+        )
+    ]
+    assert turn_result.new_events == [{"type": "BotIntent", "intent": "express greeting"}]
+    assert turn_result.output_state is None
+    assert processing_log == [{"event": "logged"}]
+
+
+@pytest.mark.asyncio
+async def test_run_colang_turn_v1_streams_error_chunk_before_reraising():
+    class Runtime:
+        async def generate_events(self, events, processing_log):
+            raise RuntimeError('Error code: 500 - {"error": {"message": "boom"}}')
+
+    class StreamingHandler:
+        def __init__(self):
+            self.chunks = []
+
+        async def push_chunk(self, chunk):
+            self.chunks.append(chunk)
+
+    streaming_handler = StreamingHandler()
+    token = streaming_handler_var.set(cast(Any, streaming_handler))
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            await run_colang_turn(
+                make_rails("1.0", Runtime()),
+                events=[{"type": "UserMessage", "text": "Hi"}],
+                state=None,
+                processing_log=[],
+            )
+    finally:
+        streaming_handler_var.reset(token)
+
+    assert json.loads(streaming_handler.chunks[0]) == {"error": {"message": "boom"}}
+    assert streaming_handler.chunks[1] == END_OF_STREAM
+
+
+@pytest.mark.asyncio
+async def test_run_colang_turn_v2_processes_events_with_default_instant_actions(monkeypatch):
+    output_state = object()
+
+    class Runtime:
+        def __init__(self):
+            self.calls = []
+
+        async def process_events(self, events, state, instant_actions, blocking):
+            self.calls.append(
+                {
+                    "events": events,
+                    "state": state,
+                    "instant_actions": instant_actions,
+                    "blocking": blocking,
+                }
+            )
+            return [{"type": "StartUtteranceBotAction", "script": "Hi"}], output_state
+
+    monkeypatch.setattr(
+        colang_turns,
+        "state_to_json",
+        lambda state: {"serialized": state is output_state},
+    )
+
+    runtime = Runtime()
+    turn_result = await run_colang_turn(
+        make_rails("2.x", runtime),
+        events=[{"type": "UtteranceUserActionFinished", "final_transcript": "Hi"}],
+        state="input-state",
+        processing_log=[],
+    )
+
+    assert runtime.calls == [
+        {
+            "events": [{"type": "UtteranceUserActionFinished", "final_transcript": "Hi"}],
+            "state": "input-state",
+            "instant_actions": ["UtteranceBotAction"],
+            "blocking": True,
+        }
+    ]
+    assert turn_result.new_events == [{"type": "StartUtteranceBotAction", "script": "Hi"}]
+    assert turn_result.output_state == {
+        "state": {"serialized": True},
+        "version": "2.x",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_colang_turn_v2_honors_configured_instant_actions(monkeypatch):
+    class Runtime:
+        def __init__(self):
+            self.instant_actions = None
+
+        async def process_events(self, events, state, instant_actions, blocking):
+            self.instant_actions = instant_actions
+            return [], object()
+
+    monkeypatch.setattr(colang_turns, "state_to_json", lambda state: {})
+
+    runtime = Runtime()
+    await run_colang_turn(
+        make_rails("2.x", runtime, instant_actions=["CustomAction"]),
+        events=[],
+        state=None,
+        processing_log=[],
+    )
+
+    assert runtime.instant_actions == ["CustomAction"]

--- a/tests/rails/llm/test_conversation_events.py
+++ b/tests/rails/llm/test_conversation_events.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.conversation import conversation_events
+from nemoguardrails.rails.llm.conversation.conversation_events import (
+    events_for_messages,
+    events_history_cache_prefix,
+    store_events_history_cache_entry,
+)
+from nemoguardrails.rails.llm.llmrails import LLMRails
+from nemoguardrails.rails.llm.utils import get_history_cache_key
+
+
+class FakeRails:
+    def __init__(self, config: RailsConfig):
+        self.config = config
+        self.events_history_cache = {}
+
+
+def make_rails(config: RailsConfig):
+    return FakeRails(config=config)
+
+
+def test_conversation_events_public_exports():
+    assert conversation_events.__all__ == [
+        "ConversationEventRails",
+        "events_for_messages",
+        "events_history_cache_prefix",
+        "store_events_history_cache_entry",
+    ]
+
+
+def test_events_for_messages_v1_converts_supported_message_roles(monkeypatch):
+    monkeypatch.setattr(conversation_events, "new_uuid", lambda: "action-1")
+    tool_calls = [{"id": "call-1", "function": {"name": "lookup", "arguments": "{}"}}]
+    passthrough_event = {"type": "UserSilent"}
+    rails = make_rails(RailsConfig(models=[], colang_version="1.0"))
+
+    events = events_for_messages(
+        rails,
+        [
+            {"role": "context", "content": {"user_name": "Ada"}},
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "assistant", "content": "", "tool_calls": tool_calls},
+            {"role": "event", "event": passthrough_event},
+        ],
+        state=None,
+    )
+
+    assert events[0] == {"type": "ContextUpdate", "data": {"user_name": "Ada"}}
+    assert events[1] == {"type": "SystemMessage", "content": "Be concise."}
+    assert events[2] == {"type": "UtteranceUserActionFinished", "final_transcript": "Hi"}
+    assert events[3] == {"type": "UserMessage", "text": "Hi"}
+    assert events[4]["type"] == "StartUtteranceBotAction"
+    assert events[4]["script"] == "Hello"
+    assert events[4]["action_uid"] == "action-1"
+    assert events[5]["type"] == "UtteranceBotActionFinished"
+    assert events[5]["final_script"] == "Hello"
+    assert events[5]["action_uid"] == "action-1"
+    assert events[6] == {"type": "BotToolCalls", "tool_calls": tool_calls}
+    assert events[7] is passthrough_event
+
+
+def test_events_for_messages_v1_reuses_longest_history_cache_prefix():
+    config = RailsConfig(models=[], colang_version="1.0")
+    rails = make_rails(config)
+    cached_prefix = [{"type": "CachedEvent"}]
+    cached_messages = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello"},
+    ]
+    rails.events_history_cache[get_history_cache_key(cached_messages)] = cached_prefix
+
+    events = events_for_messages(
+        rails,
+        cached_messages + [{"role": "user", "content": "Next"}],
+        state=None,
+    )
+
+    assert events == [
+        {"type": "CachedEvent"},
+        {"type": "UtteranceUserActionFinished", "final_transcript": "Next"},
+    ]
+    assert events is not cached_prefix
+    assert cached_prefix == [{"type": "CachedEvent"}]
+
+
+def test_events_history_cache_prefix_returns_copy_of_longest_match():
+    events_history_cache = {}
+    short_messages = [{"role": "user", "content": "Hi"}]
+    long_messages = short_messages + [{"role": "assistant", "content": "Hello"}]
+    cached_events = [{"type": "LongCachedEvent"}]
+    events_history_cache[get_history_cache_key(short_messages)] = [{"type": "ShortCachedEvent"}]
+    events_history_cache[get_history_cache_key(long_messages)] = cached_events
+
+    prefix_len, events = events_history_cache_prefix(
+        events_history_cache,
+        long_messages + [{"role": "user", "content": "Next"}],
+    )
+
+    assert prefix_len == len(long_messages)
+    assert events == [{"type": "LongCachedEvent"}]
+    assert events is not cached_events
+
+
+def test_store_events_history_cache_entry_uses_public_cache_key_shape():
+    events_history_cache = {}
+    messages = [{"role": "user", "content": "Hi"}]
+    events = [{"type": "CachedEvent"}]
+
+    store_events_history_cache_entry(events_history_cache, messages, events)
+
+    assert events_history_cache == {
+        get_history_cache_key(messages): events,
+    }
+
+
+def test_events_for_messages_v1_final_tool_message_creates_synthetic_user_message_without_tool_input_rails():
+    rails = make_rails(RailsConfig(models=[], colang_version="1.0"))
+
+    events = events_for_messages(
+        rails,
+        [
+            {"role": "user", "content": "Use the tool"},
+            {"role": "tool", "content": "tool result", "name": "lookup", "tool_call_id": "call-1"},
+        ],
+        state=None,
+    )
+
+    assert events[-1] == {"type": "UserMessage", "text": "Use the tool"}
+
+
+def test_events_for_messages_v1_final_tool_message_groups_tool_messages_when_tool_input_rails_exist():
+    config = RailsConfig(models=[], colang_version="1.0")
+    config.rails.tool_input.flows = ["check tool input"]
+    rails = make_rails(config)
+
+    events = events_for_messages(
+        rails,
+        [
+            {"role": "user", "content": "Use tools"},
+            {"role": "tool", "content": "first", "name": "lookup", "tool_call_id": "call-1"},
+            {"role": "tool", "content": "second", "tool_call_id": "call-2"},
+        ],
+        state=None,
+    )
+
+    assert events[-1] == {
+        "type": "UserToolMessages",
+        "tool_messages": [
+            {"content": "first", "name": "lookup", "tool_call_id": "call-1"},
+            {"content": "second", "name": "unknown", "tool_call_id": "call-2"},
+        ],
+    }
+
+
+def test_events_for_messages_v2_converts_supported_messages():
+    rails = make_rails(RailsConfig(models=[], colang_version="2.x"))
+    passthrough_event = {"type": "UserSilent"}
+
+    events = events_for_messages(
+        rails,
+        [
+            {"role": "context", "content": {"generation_options": {}}},
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hi"},
+            {"role": "event", "event": passthrough_event},
+        ],
+        state=SimpleNamespace(actions={}),
+    )
+
+    assert events == [
+        {"type": "ContextUpdate", "data": {"generation_options": {}}},
+        {"type": "SystemMessage", "content": "Be concise."},
+        {"type": "UtteranceUserActionFinished", "final_transcript": "Hi"},
+        passthrough_event,
+    ]
+
+
+def test_events_for_messages_v2_rejects_assistant_messages():
+    rails = make_rails(RailsConfig(models=[], colang_version="2.x"))
+
+    with pytest.raises(ValueError, match="assistant.*not supported"):
+        events_for_messages(
+            rails,
+            [{"role": "assistant", "content": "Hello"}],
+            state=SimpleNamespace(actions={}),
+        )
+
+
+def test_events_for_messages_v2_converts_tool_message_to_action_finished_event():
+    rails = make_rails(RailsConfig(models=[], colang_version="2.x"))
+    state = SimpleNamespace(actions={"call-1": SimpleNamespace(name="LookupAction")})
+
+    events = events_for_messages(
+        rails,
+        [{"role": "tool", "content": "tool result", "tool_call_id": "call-1"}],
+        state=state,
+    )
+
+    assert len(events) == 1
+    assert events[0]["type"] == "LookupActionFinished"
+    assert events[0]["action_uid"] == "call-1"
+    assert events[0]["action_name"] == "LookupAction"
+    assert events[0]["status"] == "success"
+    assert events[0]["is_success"] is True
+    assert events[0]["return_value"] == "tool result"
+    assert events[0]["events"] == []
+
+
+def test_events_for_messages_accepts_llmrails_instance():
+    rails = LLMRails(RailsConfig(models=[], colang_version="1.0"))
+
+    events = events_for_messages(
+        rails,
+        [{"role": "user", "content": "Hi"}],
+        state=None,
+    )
+
+    assert events == [{"type": "UtteranceUserActionFinished", "final_transcript": "Hi"}]
+
+
+def test_llmrails_event_history_cache_can_use_conversation_cache_helpers():
+    rails = LLMRails(RailsConfig(models=[], colang_version="1.0"))
+    messages = [{"role": "user", "content": "Hi"}]
+    events = [{"type": "CachedEvent"}]
+
+    store_events_history_cache_entry(rails.events_history_cache, messages, events)
+    prefix_len, cached_events = events_history_cache_prefix(
+        rails.events_history_cache,
+        messages + [{"role": "assistant", "content": "Hello"}],
+    )
+
+    assert rails.events_history_cache == {
+        get_history_cache_key(messages): events,
+    }
+    assert prefix_len == len(messages)
+    assert cached_events == events
+    assert cached_events is not events


### PR DESCRIPTION
## Summary

Moves Colang runtime selection, turn execution, event processing, and message-to-event conversion into focused runtime and conversation helpers.

## Why

Runtime event processing and message conversion are separate from startup wiring and generation response shaping, so they can be reviewed as a smaller behavioral surface.

## What Changed

- Adds runtime helpers for Colang 1.0 and 2.x runtime selection.
- Adds helpers for Colang turn execution and event processing.
- Adds conversation helpers for message-to-event conversion and history cache lookup.
- Adds focused tests for runtime and conversation behavior.

## Review Notes

The main compatibility points are Colang 1.0 history cache behavior, Colang 2.x state handling, and event ordering.

## Stack Position

Part 4 of 8.

- Previous: #22
- Next: #24

## Stack Context

This PR is part of an 8-PR stack that decomposes `LLMRails` internals while keeping `LLMRails` as the public compatibility surface.

Please review each PR against its parent branch, not directly against `develop`, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #20 | `stack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #21 | `stack/llmrails-02-startup-config-colang` | `stack/llmrails-01-public-contract-tests` |
| 3 | #22 | `stack/llmrails-03-startup-models-kb-actions` | `stack/llmrails-02-startup-config-colang` |
| 4 | #23 | `stack/llmrails-04-runtime-conversation` | `stack/llmrails-03-startup-models-kb-actions` |
| 5 | #24 | `stack/llmrails-05-generation-helpers` | `stack/llmrails-04-runtime-conversation` |
| 6 | #25 | `stack/llmrails-06-generation-workflow` | `stack/llmrails-05-generation-helpers` |
| 7 | #26 | `stack/llmrails-07-streaming` | `stack/llmrails-06-generation-workflow` |
| 8 | #27 | `stack/llmrails-08-checks` | `stack/llmrails-07-streaming` |

## Validation

Stack validation run on `stack/llmrails-08-checks`:

```text
poetry run pytest tests/rails/llm tests/test_llmrails_check_async.py tests/test_system_message_conversion.py tests/test_token_usage_integration.py -q
293 passed in 19.21s
```
