### PR TITLE
refactor(llmrails): extract rail check planning

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -263,6 +263,7 @@ Use Case Diagrams <reference/use-case-diagrams.md>
 Python API <reference/python-api/index>
 CLI <reference/cli/index>
 Guardrails API Server Endpoints <reference/api-server-endpoints/index>
+Migrating to 0.23 <migration/0.23>
 Migrating to 0.22 <migration/0.22>
 ```
 

--- a/docs/migration/0.23.md
+++ b/docs/migration/0.23.md
@@ -1,0 +1,14 @@
+---
+myst:
+  html_meta:
+    page: "Migrating to 0.23"
+    nav: "Migrating to 0.23"
+description: Behavior changes to account for when updating a working NeMo Guardrails configuration to 0.23.
+keywords: ["nemoguardrails 0.23", "migration", "LLMRails", "explain"]
+---
+
+# Migrating to v0.23.0
+
+## Behavior Changes
+
+- `LLMRails.explain().llm_calls` now reflects only the most recent `generate`/`generate_async` call instead of accumulating across calls on a reused `LLMRails` instance. This matches the documented "latest call" contract and is a side effect of per-request context isolation in the decomposed generation pipeline.

--- a/nemoguardrails/rails/llm/checks/__init__.py
+++ b/nemoguardrails/rails/llm/checks/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []

--- a/nemoguardrails/rails/llm/checks/rails_check.py
+++ b/nemoguardrails/rails/llm/checks/rails_check.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Message rail check helpers."""
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, List, Optional, Protocol
+
+from nemoguardrails.colang.v2_x.runtime.flows import FlowStatus, State
+from nemoguardrails.colang.v2_x.runtime.statemachine import InternalEvent, initialize_state
+from nemoguardrails.rails.llm.options import (
+    GenerationResponse,
+    RailsResult,
+    RailStatus,
+    RailType,
+)
+from nemoguardrails.utils import new_readable_uuid
+
+log = logging.getLogger(__name__)
+
+__all__ = ["RailsCheckRuntime", "check_messages"]
+
+
+class RailsCheckRuntime(Protocol):
+    config: Any
+    runtime: Any
+
+    async def generate_async(
+        self,
+        *,
+        messages: List[dict],
+        options: dict,
+    ) -> object: ...
+
+
+@dataclass
+class RailsCheckPlan:
+    messages: List[dict]
+    options: dict
+    original_content: str
+
+
+@dataclass
+class Colang2RailFlowCheck:
+    content: str
+    stopped: bool
+    rail: Optional[str]
+    state: State
+
+
+async def check_messages(
+    rails: RailsCheckRuntime,
+    messages: List[dict],
+    rail_types: Optional[List[RailType]] = None,
+) -> RailsResult:
+    """Run input/output rails for a message list and return rail check status."""
+    colang_version = rails.config.colang_version
+    plan = _plan_rails_check(
+        messages,
+        rail_types,
+        include_activated_rails_log=colang_version != "2.x",
+    )
+    if plan is None:
+        last_content = messages[-1].get("content", "") if messages else ""
+        return RailsResult(status=RailStatus.PASSED, content=last_content)
+
+    if colang_version == "2.x":
+        return await _check_colang_2_messages(rails, plan)
+
+    response = await rails.generate_async(messages=plan.messages, options=plan.options)
+
+    if not isinstance(response, GenerationResponse):
+        raise RuntimeError(f"Expected GenerationResponse, got {type(response).__name__}")
+
+    return _classify_rails_response(response, plan.original_content)
+
+
+def _plan_rails_check(
+    messages: List[dict],
+    rail_types: Optional[List[RailType]] = None,
+    *,
+    include_activated_rails_log: bool = True,
+) -> Optional[RailsCheckPlan]:
+    if rail_types is not None:
+        options: Optional[dict] = {"rails": [r.value for r in rail_types]}
+    else:
+        options = _determine_rails_from_messages(messages)
+
+    if options is None:
+        return None
+
+    rails_to_run = options["rails"]
+    if "output" in rails_to_run:
+        original_content = _get_last_content_by_role(messages, "assistant")
+    else:
+        original_content = _get_last_content_by_role(messages, "user")
+
+    messages = _normalize_messages_for_rails(deepcopy(messages), rails_to_run)
+    if include_activated_rails_log:
+        options["log"] = {"activated_rails": True}
+
+    return RailsCheckPlan(
+        messages=messages,
+        options=options,
+        original_content=original_content,
+    )
+
+
+def _classify_rails_response(
+    response: GenerationResponse,
+    original_content: str,
+) -> RailsResult:
+    blocking_rail = _get_blocking_rail(response)
+    result_content = _get_last_response_content(response)
+
+    if blocking_rail:
+        return RailsResult(status=RailStatus.BLOCKED, content=result_content, rail=blocking_rail)
+
+    if result_content != original_content:
+        return RailsResult(status=RailStatus.MODIFIED, content=result_content)
+    return RailsResult(status=RailStatus.PASSED, content=result_content)
+
+
+async def _check_colang_2_messages(
+    rails: RailsCheckRuntime,
+    plan: RailsCheckPlan,
+) -> RailsResult:
+    rails_to_run = plan.options["rails"]
+    result_content = plan.original_content
+    state = _new_colang_2_check_state(rails)
+
+    if "input" in rails_to_run:
+        input_check = await _run_colang_2_rail_flow(
+            rails=rails,
+            state=state,
+            flow_id="input rails",
+            content=_get_last_content_by_role(plan.messages, "user"),
+            content_context_key="user_message",
+        )
+        state = input_check.state
+        if input_check.stopped:
+            return RailsResult(
+                status=RailStatus.BLOCKED,
+                content=input_check.content,
+                rail=input_check.rail,
+            )
+        if rails_to_run == ["input"]:
+            result_content = input_check.content
+
+    if "output" in rails_to_run:
+        output_check = await _run_colang_2_rail_flow(
+            rails=rails,
+            state=state,
+            flow_id="output rails",
+            content=_get_last_content_by_role(plan.messages, "assistant"),
+            content_context_key="bot_message",
+        )
+        if output_check.stopped:
+            return RailsResult(
+                status=RailStatus.BLOCKED,
+                content=output_check.content,
+                rail=output_check.rail,
+            )
+        result_content = output_check.content
+
+    if result_content != plan.original_content:
+        return RailsResult(status=RailStatus.MODIFIED, content=result_content)
+    return RailsResult(status=RailStatus.PASSED, content=result_content)
+
+
+def _new_colang_2_check_state(rails: RailsCheckRuntime) -> State:
+    state = State(
+        flow_states={},
+        flow_configs=rails.runtime.flow_configs,
+        rails_config=rails.runtime.config,
+    )
+    initialize_state(state)
+    assert state.main_flow_state is not None
+
+    # check_async starts rail flows directly; it must not run the config's main
+    # flow just to obtain a parent flow for the rail-flow state.
+    state.main_flow_state.status = FlowStatus.STARTED
+    return state
+
+
+async def _run_colang_2_rail_flow(
+    *,
+    rails: RailsCheckRuntime,
+    state: State,
+    flow_id: str,
+    content: str,
+    content_context_key: str,
+) -> Colang2RailFlowCheck:
+    if flow_id not in state.flow_configs:
+        return Colang2RailFlowCheck(
+            content=content,
+            stopped=False,
+            rail=None,
+            state=state,
+        )
+
+    main_flow = state.main_flow_state
+    assert main_flow is not None
+
+    flow_instance_uid = new_readable_uuid(flow_id)
+    start_event = InternalEvent(
+        name="StartFlow",
+        arguments={
+            "flow_id": flow_id,
+            "flow_instance_uid": flow_instance_uid,
+            "flow_hierarchy_position": "0.1",
+            "source_flow_instance_uid": main_flow.uid,
+            "source_head_uid": list(main_flow.heads.values())[0].uid,
+            "$0": content,
+        },
+    )
+    output_events, state = await rails.runtime.process_events(
+        [start_event],
+        state=state,
+        blocking=True,
+        instant_actions=_colang_2_instant_actions(rails),
+    )
+    flow_state = state.flow_states[flow_instance_uid]
+    stopped = flow_state.status == FlowStatus.STOPPED
+
+    return Colang2RailFlowCheck(
+        content=_colang_2_checked_content(
+            state=state,
+            output_events=output_events,
+            original_content=content,
+            content_context_key=content_context_key,
+        ),
+        stopped=stopped,
+        # Colang 2.x check runs the wrapper rail flow directly and does not have
+        # v1-style activated-rail logs, so blocked results can only name the
+        # rail category wrapper here.
+        rail=flow_id if stopped else None,
+        state=state,
+    )
+
+
+def _colang_2_instant_actions(rails: RailsCheckRuntime) -> List[str]:
+    if rails.config.rails.actions.instant_actions is not None:
+        return rails.config.rails.actions.instant_actions
+    return ["UtteranceBotAction"]
+
+
+def _colang_2_checked_content(
+    *,
+    state: State,
+    output_events: List[dict],
+    original_content: str,
+    content_context_key: str,
+) -> str:
+    checked_content = state.context.get(content_context_key)
+    if checked_content is not None:
+        return checked_content
+
+    bot_message = state.context.get("bot_message")
+    if bot_message is not None:
+        return bot_message
+
+    bot_action_content = _last_colang_2_bot_action_content(output_events)
+    if bot_action_content is not None:
+        return bot_action_content
+
+    return original_content
+
+
+def _last_colang_2_bot_action_content(output_events: List[dict]) -> Optional[str]:
+    for event in reversed(output_events):
+        if event.get("type") == "UtteranceBotActionFinished":
+            return event.get("final_script", "")
+        if event.get("type") == "StartUtteranceBotAction":
+            return event.get("script", "")
+    return None
+
+
+def _determine_rails_from_messages(messages: List[dict]) -> Optional[dict]:
+    roles = {msg.get("role") for msg in reversed(messages)}
+    has_user = "user" in roles
+    has_assistant = "assistant" in roles
+
+    if not has_user and not has_assistant:
+        log.warning(
+            "check() called with no user or assistant messages. "
+            "Only system, context, or tool messages found. "
+            "Returning passing result without running rails."
+        )
+        return None
+
+    if has_user and has_assistant:
+        return {"rails": ["input", "output"]}
+    if has_user:
+        return {"rails": ["input"]}
+    return {"rails": ["output"]}
+
+
+def _normalize_messages_for_rails(
+    messages: List[dict],
+    rails: List[str],
+) -> List[dict]:
+    if rails == ["output"]:
+        has_user = any(msg.get("role") == "user" for msg in messages)
+        if not has_user:
+            return [{"role": "user", "content": ""}] + messages
+
+    return messages
+
+
+def _get_last_content_by_role(messages: List[dict], role: str) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == role:
+            return msg.get("content", "")
+    return ""
+
+
+def _get_blocking_rail(response: GenerationResponse) -> Optional[str]:
+    if response.log and response.log.activated_rails:
+        for rail in response.log.activated_rails:
+            if rail.stop:
+                return rail.name
+    return None
+
+
+def _get_last_response_content(response: GenerationResponse) -> str:
+    if isinstance(response.response, list) and response.response:
+        return response.response[-1].get("content", "")
+    if isinstance(response.response, str):
+        return response.response
+    return ""

--- a/nemoguardrails/rails/llm/generation/generation_request.py
+++ b/nemoguardrails/rails/llm/generation/generation_request.py
@@ -20,6 +20,7 @@ from typing import Any, List, Optional, Union
 
 from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.colang.v2_x.runtime.serialization import json_to_state
+from nemoguardrails.exceptions import InvalidStateError
 from nemoguardrails.rails.llm.options import GenerationOptions
 
 __all__ = [
@@ -127,6 +128,27 @@ def _normalize_generation_state(
     if isinstance(state, dict) and state.get("version", "1.0") == "2.x":
         return json_to_state(state["state"])
     return state
+
+
+def validate_public_state(config: Any, state: Optional[Union[dict, State]]) -> None:
+    if not isinstance(state, dict) or not state:
+        return
+
+    if config.colang_version == "1.0" and state.get("version") != "2.x":
+        if "state" in state:
+            raise InvalidStateError("Invalid Colang 1.0 state format: expected transcript state with an 'events' list.")
+        if "events" not in state:
+            raise InvalidStateError("Invalid Colang 1.0 state format: missing required 'events' list.")
+        if not isinstance(state["events"], list):
+            raise InvalidStateError("Invalid Colang 1.0 state format: 'events' must be a list.")
+        return
+
+    raise InvalidStateError(
+        "Colang 2.0 dict state is not supported by generate/generate_async. "
+        "Use rails.process_events_async(events, state) with a live State object "
+        "for trusted in-process multi-turn execution. Public serialized Colang "
+        "2.0 runtime state is not accepted."
+    )
 
 
 def _normalize_generation_options(

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -15,104 +15,71 @@
 
 """LLM Rails entry point."""
 
-import asyncio
-import importlib.util
-import json
 import logging
-import os
-import re
-import threading
-import time
 import warnings
-from functools import partial
 from typing import (
     Any,
     AsyncIterator,
     Callable,
-    Dict,
     List,
     Literal,
     Optional,
     Tuple,
     Type,
     Union,
-    cast,
     overload,
 )
 
 from typing_extensions import Self
 
-from nemoguardrails.actions.llm.generation import LLMGenerationActions
-from nemoguardrails.actions.llm.utils import (
-    extract_bot_thinking_from_events,
-    extract_tool_calls_from_events,
-    get_and_clear_response_metadata_contextvar,
-    get_colang_history,
-)
-from nemoguardrails.actions.output_mapping import is_output_blocked
-from nemoguardrails.actions.v2_x.generation import LLMGenerationActionsV2dotx
-from nemoguardrails.colang import parse_colang_file
-from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id, compute_context
-from nemoguardrails.colang.v1_0.runtime.runtime import Runtime, RuntimeV1_0
-from nemoguardrails.colang.v2_x.runtime.flows import Action, State
-from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
-from nemoguardrails.context import (
-    explain_info_var,
-    generation_options_var,
-    llm_stats_var,
-    raw_llm_request,
-    streaming_handler_var,
-)
+from nemoguardrails.colang.v1_0.runtime.runtime import Runtime
+from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.embeddings.index import EmbeddingsIndex
 from nemoguardrails.embeddings.providers import register_embedding_provider
 from nemoguardrails.embeddings.providers.base import EmbeddingModel
-from nemoguardrails.exceptions import (
-    InvalidModelConfigurationError,
-    InvalidRailsConfigurationError,
-    InvalidStateError,
-    StreamingNotSupportedError,
-)
-from nemoguardrails.kb.kb import KnowledgeBase
-from nemoguardrails.llm.cache import CacheInterface, LFUCache
-from nemoguardrails.llm.models.initializer import (
-    ModelInitializationError,
-    init_llm_model,
-)
+from nemoguardrails.llm.models.initializer import init_llm_model
 from nemoguardrails.logging.explain import ExplainInfo
-from nemoguardrails.logging.processing_log import compute_generation_log
-from nemoguardrails.logging.stats import LLMStats
 from nemoguardrails.logging.verbose import set_verbose
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
-from nemoguardrails.rails.llm.buffer import get_buffer_strategy
-from nemoguardrails.rails.llm.config import (
-    EmbeddingSearchProvider,
-    OutputRailsStreamingConfig,
-    RailsConfig,
+from nemoguardrails.rails.llm.checks import rails_check
+from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig, RailsConfig
+from nemoguardrails.rails.llm.generation.generation_context import (
+    ensure_explain_info,
+    explain_info_for_current_context,
+    start_generation_request_context,
 )
-from nemoguardrails.rails.llm.options import (
-    GenerationLog,
-    GenerationOptions,
-    GenerationResponse,
-    RailsResult,
-    RailStatus,
-    RailType,
+from nemoguardrails.rails.llm.generation.generation_request import (
+    prepare_generation_request_for_runtime,
+    validate_public_state,
 )
-from nemoguardrails.rails.llm.utils import (
-    get_action_details_from_flow_id,
-    get_history_cache_key,
+from nemoguardrails.rails.llm.generation.generation_workflow import generate_standard_async
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse, RailsResult, RailType
+from nemoguardrails.rails.llm.runtime.colang_runtime import runtime_for_colang_version
+from nemoguardrails.rails.llm.runtime.colang_turns import (
+    generate_colang_events,
+    process_colang_events,
+    process_events_semaphore,
 )
-from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
+from nemoguardrails.rails.llm.startup.config_preparation import prepare_llmrails_config
+from nemoguardrails.rails.llm.startup.config_py import load_config_py_modules, run_config_py_init_hooks
+from nemoguardrails.rails.llm.startup.config_validation import validate_llmrails_config
+from nemoguardrails.rails.llm.startup.embedding_search import EmbeddingSearchState
+from nemoguardrails.rails.llm.startup.generation_actions import register_llm_generation_actions
+from nemoguardrails.rails.llm.startup.knowledge_base import init_knowledge_base
+from nemoguardrails.rails.llm.startup.llm_action_caches import initialize_llm_action_caches
+from nemoguardrails.rails.llm.startup.llm_action_models import (
+    load_llm_action_models,
+    model_kwargs_from_config,
+    sync_update_llm_bindings,
+)
+from nemoguardrails.rails.llm.startup.tracing import create_startup_tracing_adapters
+from nemoguardrails.rails.llm.streaming.generation_stream import generation_token_stream
+from nemoguardrails.rails.llm.streaming.streaming_output_rails import run_output_rails_in_streaming
+from nemoguardrails.streaming import StreamingHandler
 from nemoguardrails.types import LLMModel
-from nemoguardrails.utils import (
-    extract_error_json,
-    get_or_create_event_loop,
-    new_event_dict,
-    new_uuid,
-)
+from nemoguardrails.utils import get_or_create_event_loop
 
 log = logging.getLogger(__name__)
-
-process_events_semaphore = asyncio.Semaphore(1)
 
 
 def _wrap_legacy_llm(llm):
@@ -136,8 +103,28 @@ class LLMRails:
     """Rails based on a given configuration."""
 
     config: RailsConfig
+    embedding_search: EmbeddingSearchState
+    _explain_info: Optional[ExplainInfo]
+    _verbose: bool
     llm: Optional[LLMModel]
+    llm_generation_actions: Any
     runtime: Runtime
+
+    @property
+    def explain_info(self) -> Optional[ExplainInfo]:
+        return self._explain_info
+
+    @explain_info.setter
+    def explain_info(self, explain_info: Optional[ExplainInfo]) -> None:
+        self._explain_info = explain_info
+
+    @property
+    def verbose(self) -> bool:
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, verbose: bool) -> None:
+        self._verbose = verbose
 
     def __init__(
         self,
@@ -163,180 +150,53 @@ class LLMRails:
         if self.verbose:
             set_verbose(True, llm_calls=True)
 
-        # We allow the user to register additional embedding search providers, so we keep
-        # an index of them.
-        self.embedding_search_providers = {}
-
-        # The default embeddings model is using FastEmbed
-        self.default_embedding_model = "all-MiniLM-L6-v2"
-        self.default_embedding_engine = "FastEmbed"
-        self.default_embedding_params = {}
+        self.embedding_search = EmbeddingSearchState.default()
 
         # We keep a cache of the events history associated with a sequence of user messages.
         # TODO: when we update the interface to allow to return a "state object", this
         #   should be removed
         self.events_history_cache = {}
 
-        # We also load the default flows from the `default_flows.yml` file in the current folder.
-        # But only for version 1.0.
-        # TODO: decide on the default flows for 2.x.
-        if config.colang_version == "1.0":
-            # We also load the default flows from the `llm_flows.co` file in the current folder.
-            current_folder = os.path.dirname(__file__)
-            default_flows_file = "llm_flows.co"
-            default_flows_path = os.path.join(current_folder, default_flows_file)
-            with open(default_flows_path, "r") as f:
-                default_flows_content = f.read()
-                default_flows = parse_colang_file(default_flows_file, default_flows_content)["flows"]
-
-            # We mark all the default flows as system flows.
-            for flow_config in default_flows:
-                flow_config["is_system_flow"] = True
-
-            # We add the default flows to the config.
-            self.config.flows.extend(default_flows)
-
-            # We also need to load the content from the components library.
-            library_path = os.path.join(os.path.dirname(__file__), "../../library")
-            for root, dirs, files in os.walk(library_path):
-                for file in files:
-                    # Extract the full path for the file
-                    full_path = os.path.join(root, file)
-                    if file.endswith(".co"):
-                        log.debug(f"Loading file: {full_path}")
-                        with open(full_path, "r", encoding="utf-8") as f:
-                            content = parse_colang_file(file, content=f.read(), version=config.colang_version)
-                            if not content:
-                                continue
-
-                        # We mark all the flows coming from the guardrails library as system flows.
-                        for flow_config in content["flows"]:
-                            flow_config["is_system_flow"] = True
-
-                        # We load all the flows
-                        self.config.flows.extend(content["flows"])
-
-                        # And all the messages as well, if they have not been overwritten
-                        for message_id, utterances in content.get("bot_messages", {}).items():
-                            if message_id not in self.config.bot_messages:
-                                self.config.bot_messages[message_id] = utterances
-
-        # Last but not least, we mark all the flows that are used in any of the rails
-        # as system flows (so they don't end up in the prompt).
-
-        rail_flow_ids = config.rails.input.flows + config.rails.output.flows + config.rails.retrieval.flows
-
-        for flow_config in self.config.flows:
-            if flow_config.get("id") in rail_flow_ids:
-                flow_config["is_system_flow"] = True
-
-                # We also mark them as subflows by default, to simplify the syntax
-                flow_config["is_subflow"] = True
+        prepared_config = prepare_llmrails_config(
+            config=self.config,
+            default_embedding_model=self.embedding_search.default_model,
+            default_embedding_engine=self.embedding_search.default_engine,
+            default_embedding_params=self.embedding_search.default_params,
+        )
+        self.config = prepared_config.config
+        self.embedding_search.update_defaults(
+            default_model=prepared_config.default_embedding_model,
+            default_engine=prepared_config.default_embedding_engine,
+            default_params=prepared_config.default_embedding_params,
+        )
 
         # We check if the configuration or any of the imported ones have config.py modules.
-        config_modules = []
-        for _path in list(self.config.imported_paths.values() if self.config.imported_paths else []) + [
-            self.config.config_path
-        ]:
-            if _path:
-                filepath = os.path.join(_path, "config.py")
-                if os.path.exists(filepath):
-                    filename = os.path.basename(filepath)
-                    spec = importlib.util.spec_from_file_location(filename, filepath)
-                    if spec and spec.loader:
-                        config_module = importlib.util.module_from_spec(spec)
-                        spec.loader.exec_module(config_module)
-                        config_modules.append(config_module)
-
-        colang_version_to_runtime: Dict[str, Type[Runtime]] = {
-            "1.0": RuntimeV1_0,
-            "2.x": RuntimeV2_x,
-        }
-        if config.colang_version not in colang_version_to_runtime:
-            raise InvalidRailsConfigurationError(
-                f"Unsupported colang version: {config.colang_version}. Supported versions: {list(colang_version_to_runtime.keys())}"
-            )
+        config_modules = load_config_py_modules(self.config)
 
         # First, we initialize the runtime.
-        self.runtime = colang_version_to_runtime[config.colang_version](config=config, verbose=verbose)
+        self.runtime = runtime_for_colang_version(config=config, verbose=verbose)
 
         # If we have a config_modules with an `init` function, we call it.
         # We need to call this here because the `init` might register additional
         # LLM providers.
-        for config_module in config_modules:
-            if hasattr(config_module, "init"):
-                config_module.init(self)
+        run_config_py_init_hooks(self, config_modules)
 
-        # If we have a customized embedding model, we'll use it.
-        for model in self.config.models:
-            if model.type == "embeddings":
-                self.default_embedding_model = model.model
-                self.default_embedding_engine = model.engine
-                self.default_embedding_params = model.parameters or {}
-
-                for esp in [
-                    self.config.core.embedding_search_provider,
-                    self.config.knowledge_base.embedding_search_provider,
-                ]:
-                    if esp.name != "default":
-                        continue
-                    if "embedding_model" not in esp.parameters and model.model is not None:
-                        esp.parameters["embedding_model"] = model.model
-                    if "embedding_engine" not in esp.parameters and model.engine is not None:
-                        esp.parameters["embedding_engine"] = model.engine
-
-                break
-
-        # InteractionLogAdapters used for tracing
-        # We ensure that it is used after config.py is loaded
-        if config.tracing:
-            from nemoguardrails.tracing import create_log_adapters
-
-            self._log_adapters = create_log_adapters(config.tracing)
-        else:
-            self._log_adapters = None
+        self._log_adapters = create_startup_tracing_adapters(config)
 
         # We run some additional checks on the config
-        self._validate_config()
+        validate_llmrails_config(self.config)
 
         # Next, we initialize the LLM engines (main engine and action engines if specified).
         self._init_llms()
 
         # Next, we initialize the LLM Generate actions and register them.
-        llm_generation_actions_class = (
-            LLMGenerationActions if config.colang_version == "1.0" else LLMGenerationActionsV2dotx
-        )
-        self.llm_generation_actions = llm_generation_actions_class(
-            config=config,
-            llm=self.llm,
-            llm_task_manager=self.runtime.llm_task_manager,
-            get_embedding_search_provider_instance=self._get_embeddings_search_provider_instance,
-            verbose=verbose,
-        )
+        register_llm_generation_actions(self, verbose=verbose)
 
-        # If there's already an action registered, we don't override.
-        self.runtime.register_actions(self.llm_generation_actions, override=False)
-
-        # Next, we initialize the Knowledge Base
-        # There are still some edge cases not covered by nest_asyncio.
-        # Using a separate thread always for now.
-        loop = get_or_create_event_loop()
-        if True or check_sync_call_from_async_loop():
-            t = threading.Thread(target=asyncio.run, args=(self._init_kb(),))
-            t.start()
-            t.join()
-        else:
-            loop.run_until_complete(self._init_kb())
-
-        # We also register the kb as a parameter that can be passed to actions.
-        self.runtime.register_action_param("kb", self.kb)
+        # Next, we initialize the Knowledge Base.
+        init_knowledge_base(self)
 
         # Reference to the general ExplainInfo object.
         self.explain_info = None
-
-        from nemoguardrails.telemetry import report_usage
-
-        report_usage(config, deployment_type="library", rails_engine="LLMRails")
 
     def update_llm(self, llm: LLMModel):
         """Replace the main LLM with the provided one.
@@ -346,55 +206,7 @@ class LLMRails:
         """
         if not isinstance(llm, LLMModel):
             llm = _wrap_legacy_llm(llm)
-        self.llm = llm
-        self.llm_generation_actions.llm = llm
-        self.runtime.register_action_param("llm", llm)
-
-    def _validate_config(self):
-        """Runs additional validation checks on the config."""
-
-        if self.config.colang_version == "1.0":
-            existing_flows_names = set([flow.get("id") for flow in self.config.flows])
-        else:
-            existing_flows_names = set([flow.get("name") for flow in self.config.flows])
-
-        for flow_name in self.config.rails.input.flows:
-            # content safety check input/output flows are special as they have parameters
-            flow_name = _normalize_flow_id(flow_name)
-            if flow_name not in existing_flows_names:
-                raise InvalidRailsConfigurationError(f"The provided input rail flow `{flow_name}` does not exist")
-
-        for flow_name in self.config.rails.output.flows:
-            flow_name = _normalize_flow_id(flow_name)
-            if flow_name not in existing_flows_names:
-                raise InvalidRailsConfigurationError(f"The provided output rail flow `{flow_name}` does not exist")
-
-        for flow_name in self.config.rails.retrieval.flows:
-            if flow_name not in existing_flows_names:
-                raise InvalidRailsConfigurationError(f"The provided retrieval rail flow `{flow_name}` does not exist")
-
-        # If both passthrough mode and single call mode are specified, we raise an exception.
-        if self.config.passthrough and self.config.rails.dialog.single_call.enabled:
-            raise InvalidRailsConfigurationError(
-                "The passthrough mode and the single call dialog rails mode can't be used at the same time. "
-                "The single call mode needs to use an altered prompt when prompting the LLM. "
-            )
-
-    async def _init_kb(self):
-        """Initializes the knowledge base."""
-        self.kb = None
-
-        if not self.config.docs:
-            return
-
-        documents = [doc.content for doc in self.config.docs]
-        self.kb = KnowledgeBase(
-            documents=documents,
-            config=self.config.knowledge_base,
-            get_embedding_search_provider_instance=self._get_embeddings_search_provider_instance,
-        )
-        self.kb.init()
-        await self.kb.build()
+        sync_update_llm_bindings(self, llm)
 
     def _prepare_model_kwargs(self, model_config):
         """
@@ -406,15 +218,7 @@ class LLMRails:
         Returns:
             dict: The prepared kwargs for model initialization
         """
-        kwargs = model_config.parameters or {}
-
-        # If the optional API Key Environment Variable is set, add it to kwargs
-        if model_config.api_key_env_var:
-            api_key = os.environ.get(model_config.api_key_env_var)
-            if api_key:
-                kwargs["api_key"] = api_key
-
-        return kwargs
+        return model_kwargs_from_config(model_config)
 
     def _init_llms(self):
         """
@@ -429,335 +233,8 @@ class LLMRails:
         Raises:
             ModelInitializationError: If any model initialization fails
         """
-        from nemoguardrails._compat.langchain_kwargs import check_langchain_kwargs
-        from nemoguardrails.llm.frameworks import get_default_framework
-
-        models_to_check = (
-            [model for model in self.config.models if model.type != "main"] if self.llm else self.config.models
-        )
-        check_langchain_kwargs(models_to_check, get_default_framework())
-
-        # If the user supplied an already-constructed LLM via the constructor we
-        # treat it as the *main* model, but **still** iterate through the
-        # configuration to load any additional models (e.g. `content_safety`).
-
-        if self.llm:
-            # If an LLM was provided via constructor, use it as the main LLM
-            # Log a warning if a main LLM is also specified in the config
-            if any(model.type == "main" for model in self.config.models):
-                log.warning(
-                    "Both an LLM was provided via constructor and a main LLM is specified in the config. "
-                    "The LLM provided via constructor will be used and the main LLM from config will be ignored."
-                )
-            self.runtime.register_action_param("llm", self.llm)
-
-        else:
-            # Otherwise, initialize the main LLM from the config
-            main_model = next((model for model in self.config.models if model.type == "main"), None)
-
-            if main_model and main_model.model:
-                kwargs = self._prepare_model_kwargs(main_model)
-                self.llm = init_llm_model(
-                    model_name=main_model.model,
-                    provider_name=main_model.engine,
-                    mode="chat",
-                    kwargs=kwargs,
-                )
-                self.runtime.register_action_param("llm", self.llm)
-
-            else:
-                log.info("No main LLM specified in the config and no LLM provided via constructor.")
-
-        llms = dict()
-
-        for llm_config in self.config.models:
-            if llm_config.type in ["embeddings", "jailbreak_detection"]:
-                continue
-
-            # If a constructor LLM is provided, skip initializing any 'main' model from config
-            if self.llm and llm_config.type == "main":
-                continue
-
-            try:
-                model_name = llm_config.model
-                if not model_name:
-                    raise InvalidModelConfigurationError(
-                        f"`model` field must be set in model configuration: {llm_config.model_dump_json()}"
-                    )
-
-                provider_name = llm_config.engine
-                kwargs = self._prepare_model_kwargs(llm_config)
-                mode = llm_config.mode
-
-                llm_model = init_llm_model(
-                    model_name=model_name,
-                    provider_name=provider_name,
-                    mode=mode,
-                    kwargs=kwargs,
-                )
-
-                # Configure the model based on its type
-                if llm_config.type == "main":
-                    # If a main LLM was already injected, skip creating another
-                    # one. Otherwise, create and register it.
-                    if not self.llm:
-                        self.llm = llm_model
-                        self.runtime.register_action_param("llm", self.llm)
-                else:
-                    model_name = f"{llm_config.type}_llm"
-                    if not hasattr(self, model_name):
-                        setattr(self, model_name, llm_model)
-                    self.runtime.register_action_param(model_name, getattr(self, model_name))
-                    # this is used for content safety and topic control
-                    llms[llm_config.type] = getattr(self, model_name)
-
-            except ModelInitializationError as e:
-                log.error("Failed to initialize model: %s", str(e))
-                raise
-            except Exception as e:
-                log.error("Unexpected error initializing model: %s", str(e))
-                raise
-
-        self.runtime.register_action_param("llms", llms)
-
-        self._initialize_model_caches()
-
-    def _create_model_cache(self, model) -> LFUCache:
-        """
-        Create cache instance for a model based on its configuration.
-
-        Args:
-            model: The model configuration object
-
-        Returns:
-            LFUCache: The cache instance
-        """
-
-        if model.cache.maxsize <= 0:
-            raise ValueError(
-                f"Invalid cache maxsize for model '{model.type}': {model.cache.maxsize}. "
-                "Capacity must be greater than 0. Skipping cache creation."
-            )
-
-        stats_logging_interval = None
-        if model.cache.stats.enabled and model.cache.stats.log_interval is not None:
-            stats_logging_interval = model.cache.stats.log_interval
-
-        cache = LFUCache(
-            maxsize=model.cache.maxsize,
-            track_stats=model.cache.stats.enabled,
-            stats_logging_interval=stats_logging_interval,
-        )
-
-        log.info(f"Created cache for model '{model.type}' with maxsize {model.cache.maxsize}")
-
-        return cache
-
-    def _initialize_model_caches(self) -> None:
-        """Initialize caches for configured models."""
-        model_caches: Optional[Dict[str, CacheInterface]] = dict()
-        for model in self.config.models:
-            if model.type in ["main", "embeddings"]:
-                continue
-
-            if model.cache and model.cache.enabled:
-                cache = self._create_model_cache(model)
-                model_caches[model.type] = cache
-
-                log.info(
-                    f"Initialized model '{model.type}' with cache %s",
-                    "enabled" if cache else "disabled",
-                )
-
-        if model_caches:
-            self.runtime.register_action_param("model_caches", model_caches)
-
-    def _get_embeddings_search_provider_instance(
-        self, esp_config: Optional[EmbeddingSearchProvider] = None
-    ) -> EmbeddingsIndex:
-        if esp_config is None:
-            esp_config = EmbeddingSearchProvider()
-
-        if esp_config.name == "default":
-            from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
-
-            return BasicEmbeddingsIndex(
-                embedding_model=esp_config.parameters.get("embedding_model", self.default_embedding_model),
-                embedding_engine=esp_config.parameters.get("embedding_engine", self.default_embedding_engine),
-                embedding_params=esp_config.parameters.get("embedding_parameters", self.default_embedding_params),
-                cache_config=esp_config.cache,
-                # We make sure we also pass additional relevant params.
-                **{
-                    k: v
-                    for k, v in esp_config.parameters.items()
-                    if k
-                    in [
-                        "use_batching",
-                        "max_batch_size",
-                        "matx_batch_hold",
-                        "search_threshold",
-                    ]
-                    and v is not None
-                },
-            )
-        else:
-            if esp_config.name not in self.embedding_search_providers:
-                raise Exception(f"Unknown embedding search provider: {esp_config.name}")
-            else:
-                kwargs = esp_config.parameters
-                return self.embedding_search_providers[esp_config.name](**kwargs)
-
-    def _get_events_for_messages(self, messages: List[dict], state: Any):
-        """Return the list of events corresponding to the provided messages.
-
-        Tries to find a prefix of messages for which we have already a list of events
-        in the cache. For the rest, they are converted as is.
-
-        The reason this cache exists is that we want to benefit from events generated in
-        previous turns, which can't be computed again because it would be expensive (e.g.,
-        involving multiple LLM calls).
-
-        When an explicit state object will be added, this mechanism can be removed.
-
-        Args:
-            messages: The list of messages.
-
-        Returns:
-            A list of events.
-        """
-        events = []
-
-        if self.config.colang_version == "1.0":
-            # We try to find the longest prefix of messages for which we have a cache
-            # of events.
-            p = len(messages) - 1
-            while p > 0:
-                cache_key = get_history_cache_key(messages[0:p])
-                if cache_key in self.events_history_cache:
-                    events = self.events_history_cache[cache_key].copy()
-                    break
-
-                p -= 1
-
-            # For the rest of the messages, we transform them directly into events.
-            # TODO: Move this to separate function once more types of messages are supported.
-            for idx in range(p, len(messages)):
-                msg = messages[idx]
-                if msg["role"] == "user":
-                    events.append(
-                        {
-                            "type": "UtteranceUserActionFinished",
-                            "final_transcript": msg["content"],
-                        }
-                    )
-
-                    # If it's not the last message, we also need to add the `UserMessage` event
-                    if idx != len(messages) - 1:
-                        events.append(
-                            {
-                                "type": "UserMessage",
-                                "text": msg["content"],
-                            }
-                        )
-
-                elif msg["role"] == "assistant":
-                    if msg.get("tool_calls"):
-                        events.append({"type": "BotToolCalls", "tool_calls": msg["tool_calls"]})
-                    else:
-                        action_uid = new_uuid()
-                        start_event = new_event_dict(
-                            "StartUtteranceBotAction",
-                            script=msg["content"],
-                            action_uid=action_uid,
-                        )
-                        finished_event = new_event_dict(
-                            "UtteranceBotActionFinished",
-                            final_script=msg["content"],
-                            is_success=True,
-                            action_uid=action_uid,
-                        )
-                        events.extend([start_event, finished_event])
-                elif msg["role"] == "context":
-                    events.append({"type": "ContextUpdate", "data": msg["content"]})
-                elif msg["role"] == "event":
-                    events.append(msg["event"])
-                elif msg["role"] == "system":
-                    # Handle system messages - convert them to SystemMessage events
-                    events.append({"type": "SystemMessage", "content": msg["content"]})
-                elif msg["role"] == "tool":
-                    # For the last tool message, create grouped tool event and synthetic UserMessage
-                    if idx == len(messages) - 1:
-                        # Find the original user message for response generation
-                        user_message = None
-                        for prev_msg in reversed(messages[:idx]):
-                            if prev_msg["role"] == "user":
-                                user_message = prev_msg["content"]
-                                break
-
-                        if user_message:
-                            # If tool input rails are configured, group all tool messages
-                            if self.config.rails.tool_input.flows:
-                                # Collect all tool messages for grouped processing
-                                tool_messages = []
-                                for tool_idx in range(len(messages)):
-                                    if messages[tool_idx]["role"] == "tool":
-                                        tool_messages.append(
-                                            {
-                                                "content": messages[tool_idx]["content"],
-                                                "name": messages[tool_idx].get("name", "unknown"),
-                                                "tool_call_id": messages[tool_idx].get("tool_call_id", ""),
-                                            }
-                                        )
-
-                                events.append(
-                                    {
-                                        "type": "UserToolMessages",
-                                        "tool_messages": tool_messages,
-                                    }
-                                )
-
-                            else:
-                                events.append({"type": "UserMessage", "text": user_message})
-
-        else:
-            for idx in range(len(messages)):
-                msg = messages[idx]
-                if msg["role"] == "user":
-                    events.append(
-                        {
-                            "type": "UtteranceUserActionFinished",
-                            "final_transcript": msg["content"],
-                        }
-                    )
-
-                elif msg["role"] == "assistant":
-                    raise ValueError(
-                        "Providing `assistant` messages as input is not supported for Colang 2.0 configurations."
-                    )
-                elif msg["role"] == "context":
-                    events.append({"type": "ContextUpdate", "data": msg["content"]})
-                elif msg["role"] == "event":
-                    events.append(msg["event"])
-                elif msg["role"] == "system":
-                    # Handle system messages - convert them to SystemMessage events
-                    events.append({"type": "SystemMessage", "content": msg["content"]})
-                elif msg["role"] == "tool":
-                    action_uid = msg["tool_call_id"]
-                    return_value = msg["content"]
-                    action: Action = state.actions[action_uid]
-                    events.append(
-                        new_event_dict(
-                            f"{action.name}Finished",
-                            action_uid=action_uid,
-                            action_name=action.name,
-                            status="success",
-                            is_success=True,
-                            return_value=return_value,
-                            events=[],
-                        )
-                    )
-
-        return events
+        load_llm_action_models(self, init_llm=init_llm_model)
+        initialize_llm_action_caches(self)
 
     @staticmethod
     def _ensure_explain_info() -> ExplainInfo:
@@ -766,38 +243,7 @@ class LLMRails:
         Returns:
             A ExplainInfo class containing the llm calls' statistics
         """
-        explain_info = explain_info_var.get()
-        if explain_info is None:
-            explain_info = ExplainInfo()
-            explain_info_var.set(explain_info)
-
-        return explain_info
-
-    def _validate_public_state(self, state: Optional[Union[dict, State]]) -> None:
-        """Validate public dict state passed through generate/generate_async."""
-        if not isinstance(state, dict) or not state:
-            return
-
-        if self.config.colang_version == "1.0" and state.get("version") != "2.x":
-            if "state" in state:
-                raise InvalidStateError(
-                    "Invalid Colang 1.0 state format: expected transcript state with an 'events' list."
-                )
-            if "events" not in state:
-                raise InvalidStateError(
-                    "Invalid Colang 1.0 state format: state must contain an 'events' key. "
-                    "Use an empty dict {} to start a new conversation."
-                )
-            if not isinstance(state["events"], list):
-                raise InvalidStateError("Invalid Colang 1.0 state format: 'events' must be a list.")
-            return
-
-        raise InvalidStateError(
-            "Colang 2.0 dict state is not supported by generate/generate_async. "
-            "Use rails.process_events_async(events, state) with a live State object "
-            "for trusted in-process multi-turn execution. Public serialized Colang "
-            "2.0 runtime state is not accepted."
-        )
+        return ensure_explain_info()
 
     async def generate_async(
         self,
@@ -831,401 +277,38 @@ class LLMRails:
             The completion (when a prompt is provided) or the next message.
 
         System messages are not yet supported."""
-        # convert options to gen_options of type GenerationOptions
-        gen_options: Optional[GenerationOptions] = None
+        validate_public_state(self.config, state)
+        prepared_request = prepare_generation_request_for_runtime(
+            prompt=prompt,
+            messages=messages,
+            options=options,
+            state=state,
+        )
+        prompt = prepared_request.prompt
+        request_messages = prepared_request.request_messages
+        messages = prepared_request.runtime_messages
+        gen_options = prepared_request.options
+        state = prepared_request.state
 
-        if prompt is None and messages is None:
-            raise ValueError("Either prompt or messages must be provided.")
+        request_context = start_generation_request_context(
+            gen_options=gen_options,
+            messages=request_messages,
+            streaming_handler=streaming_handler,
+        )
+        try:
+            if prepared_request.needs_llm and not self.llm:
+                log.warning("No main LLM specified in the config and no LLM provided via constructor.")
 
-        if prompt is not None and messages is not None:
-            raise ValueError("Only one of prompt or messages can be provided.")
-
-        if prompt is not None:
-            # Currently, we transform the prompt request into a single turn conversation
-            messages = [{"role": "user", "content": prompt}]
-
-        # If a state object is specified, then we switch to "generation options" mode.
-        # This is because we want the output to be a GenerationResponse which will contain
-        # the output state.
-        if state is not None:
-            self._validate_public_state(state)
-
-            if options is None:
-                gen_options = GenerationOptions()
-            elif isinstance(options, dict):
-                gen_options = GenerationOptions(**options)
-            else:
-                gen_options = options
-        else:
-            # We allow options to be specified both as a dict and as an object.
-            if options and isinstance(options, dict):
-                gen_options = GenerationOptions(**options)
-            elif isinstance(options, GenerationOptions):
-                gen_options = options
-            elif options is None:
-                gen_options = None
-            else:
-                raise TypeError("options must be a dict or GenerationOptions")
-
-        # Save the generation options in the current async context.
-        # At this point, gen_options is either None or GenerationOptions
-        generation_options_var.set(gen_options)
-
-        needs_llm = gen_options is None or gen_options.rails.dialog is not False
-        if needs_llm and not self.llm:
-            log.warning("No main LLM specified in the config and no LLM provided via constructor.")
-
-        if streaming_handler:
-            streaming_handler_var.set(streaming_handler)
-
-        # Initialize the object with additional explanation information.
-        # We allow this to also be set externally. This is useful when multiple parallel
-        # requests are made.
-        self.explain_info = self._ensure_explain_info()
-
-        raw_llm_request.set(messages)
-
-        # If we have generation options, we also add them to the context
-        if gen_options:
-            messages = [
-                {
-                    "role": "context",
-                    "content": {"generation_options": gen_options.model_dump()},
-                }
-            ] + (messages or [])
-
-        # If the last message is from the assistant, rather than the user, then
-        # we move that to the `$bot_message` variable. This is to enable a more
-        # convenient interface. (only when dialog rails are disabled)
-        if messages and messages[-1]["role"] == "assistant" and gen_options and gen_options.rails.dialog is False:
-            # We already have the first message with a context update, so we use that
-            messages[0]["content"]["bot_message"] = messages[-1]["content"]
-            messages = messages[0:-1]
-
-        # TODO: Add support to load back history of events, next to history of messages
-        #   This is important as without it, the LLM prediction is not as good.
-
-        t0 = time.time()
-
-        # Initialize the LLM stats
-        llm_stats = LLMStats()
-        llm_stats_var.set(llm_stats)
-        processing_log = []
-
-        # The array of events corresponding to the provided sequence of messages.
-        events = self._get_events_for_messages(messages, state)  # type: ignore
-
-        if self.config.colang_version == "1.0":
-            # If we had a state object, we also need to prepend the events from the state.
-            state_events = []
-            if state:
-                assert isinstance(state, dict)
-                state_events = state["events"]
-
-            new_events = []
-            # Compute the new events.
-            try:
-                new_events = await self.runtime.generate_events(state_events + events, processing_log=processing_log)
-                output_state = None
-
-            except Exception as e:
-                log.error("Error in generate_async: %s", e, exc_info=True)
-                streaming_handler = streaming_handler_var.get()
-                if streaming_handler:
-                    # Push an error chunk instead of None.
-                    error_message = str(e)
-                    error_dict = extract_error_json(error_message)
-                    error_payload: str = json.dumps(error_dict)
-                    await streaming_handler.push_chunk(error_payload)
-                    # push a termination signal
-                    await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
-                # Re-raise the exact exception
-                raise
-        else:
-            # In generation mode, by default the bot response is an instant action.
-            instant_actions = ["UtteranceBotAction"]
-            if self.config.rails.actions.instant_actions is not None:
-                instant_actions = self.config.rails.actions.instant_actions
-
-            # Cast this explicitly to avoid certain warnings
-            runtime: RuntimeV2_x = cast(RuntimeV2_x, self.runtime)
-
-            # Compute the new events.
-            # In generation mode, the processing is always blocking, i.e., it waits for
-            # all local actions (sync and async).
-            new_events, _output_state = await runtime.process_events(
-                events, state=state, instant_actions=instant_actions, blocking=True
+            return await generate_standard_async(
+                self,
+                prompt=prompt,
+                messages=messages,
+                gen_options=gen_options,
+                state=state,
+                request_context=request_context,
             )
-            # The runtime State for 2.x is not publicly exposed through generate_async.
-            # Callers that need stateful 2.x execution use process_events_async, which
-            # returns the live State object directly.
-            output_state = None
-
-        # Extract and join all the messages from StartUtteranceBotAction events as the response.
-        responses = []
-        response_tool_calls = []
-        response_events = []
-        new_extra_events = []
-        exception = None
-
-        # The processing is different for Colang 1.0 and 2.0
-        if self.config.colang_version == "1.0":
-            for event in new_events:
-                if event["type"] == "StartUtteranceBotAction":
-                    # Check if we need to remove a message
-                    if event["script"] == "(remove last message)":
-                        responses = responses[0:-1]
-                    else:
-                        responses.append(event["script"])
-                elif event["type"].endswith("Exception"):
-                    exception = event
-
-        else:
-            for event in new_events:
-                start_action_match = re.match(r"Start(.*Action)", event["type"])
-
-                if start_action_match:
-                    action_name = start_action_match[1]
-                    # TODO: is there an elegant way to extract just the arguments?
-                    arguments = {
-                        k: v
-                        for k, v in event.items()
-                        if k != "type"
-                        and k != "uid"
-                        and k != "event_created_at"
-                        and k != "source_uid"
-                        and k != "action_uid"
-                    }
-                    response_tool_calls.append(
-                        {
-                            "id": event["action_uid"],
-                            "type": "function",
-                            "function": {"name": action_name, "arguments": arguments},
-                        }
-                    )
-
-                elif event["type"] == "UtteranceBotActionFinished":
-                    responses.append(event["final_script"])
-                else:
-                    # We just append the event
-                    response_events.append(event)
-
-        if exception:
-            new_message: dict = {"role": "exception", "content": exception}
-
-        else:
-            # Ensure all items in responses are strings
-            responses = [str(response) if not isinstance(response, str) else response for response in responses]
-            new_message: dict = {"role": "assistant", "content": "\n".join(responses)}
-        if response_tool_calls:
-            new_message["tool_calls"] = response_tool_calls
-        if response_events:
-            new_message["events"] = response_events
-
-        if self.config.colang_version == "1.0":
-            events.extend(new_events)
-            events.extend(new_extra_events)
-
-            # If a state object is not used, then we use the implicit caching
-            if state is None:
-                # Save the new events in the history and update the cache
-                cache_key = get_history_cache_key((messages) + [new_message])  # type: ignore
-                self.events_history_cache[cache_key] = events
-            else:
-                output_state = {"events": events}
-
-        # If logging is enabled, we log the conversation
-        # TODO: add support for logging flag
-        self.explain_info.colang_history = get_colang_history(events)
-        if self.verbose:
-            log.info(f"Conversation history so far: \n{self.explain_info.colang_history}")
-
-        total_time = time.time() - t0
-        log.info("--- :: Total processing took %.2f seconds. LLM Stats: %s" % (total_time, llm_stats))
-
-        # If there is a streaming handler, we make sure we close it now
-        streaming_handler = streaming_handler_var.get()
-        if streaming_handler:
-            # print("Closing the stream handler explicitly")
-            await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
-
-        # IF tracing is enabled we need to set GenerationLog attrs
-        original_log_options = None
-        if self.config.tracing.enabled:
-            if gen_options is None:
-                gen_options = GenerationOptions()
-            else:
-                # create a copy of the gen_options to avoid modifying the original
-                gen_options = gen_options.model_copy(deep=True)
-            original_log_options = gen_options.log.model_copy(deep=True)
-
-            # enable log options
-            # it is aggressive, but these are required for tracing
-            if (
-                not gen_options.log.activated_rails
-                or not gen_options.log.llm_calls
-                or not gen_options.log.internal_events
-            ):
-                gen_options.log.activated_rails = True
-                gen_options.log.llm_calls = True
-                gen_options.log.internal_events = True
-
-        tool_calls = extract_tool_calls_from_events(new_events)
-        llm_metadata = get_and_clear_response_metadata_contextvar()
-        reasoning_content = extract_bot_thinking_from_events(new_events)
-        # If we have generation options, we prepare a GenerationResponse instance.
-        if gen_options:
-            # If a prompt was used, we only need to return the content of the message.
-            if prompt:
-                res = GenerationResponse(response=new_message["content"])
-            else:
-                res = GenerationResponse(response=[new_message])
-
-            if reasoning_content:
-                res.reasoning_content = reasoning_content
-
-            if tool_calls:
-                res.tool_calls = tool_calls
-
-            if llm_metadata:
-                res.llm_metadata = llm_metadata
-
-            if self.config.colang_version == "1.0":
-                # If output variables are specified, we extract their values
-                if gen_options and gen_options.output_vars:
-                    context = compute_context(events)
-                    output_vars = gen_options.output_vars
-                    if isinstance(output_vars, list):
-                        # If we have only a selection of keys, we filter to only that.
-                        res.output_data = {k: context.get(k) for k in output_vars}
-                    else:
-                        # Otherwise, we return the full context
-                        res.output_data = context
-
-                _log = compute_generation_log(processing_log)
-
-                # Include information about activated rails and LLM calls if requested
-                log_options = gen_options.log if gen_options else None
-                if log_options and (log_options.activated_rails or log_options.llm_calls):
-                    res.log = GenerationLog()
-
-                    # We always include the stats
-                    res.log.stats = _log.stats
-
-                    if log_options.activated_rails:
-                        res.log.activated_rails = _log.activated_rails
-
-                    if log_options.llm_calls:
-                        res.log.llm_calls = []
-                        for activated_rail in _log.activated_rails:
-                            for executed_action in activated_rail.executed_actions:
-                                res.log.llm_calls.extend(executed_action.llm_calls)
-
-                # Include internal events if requested
-                if log_options and log_options.internal_events:
-                    if res.log is None:
-                        res.log = GenerationLog()
-
-                    res.log.internal_events = new_events
-
-                # Include the Colang history if requested
-                if log_options and log_options.colang_history:
-                    if res.log is None:
-                        res.log = GenerationLog()
-
-                    res.log.colang_history = get_colang_history(events)
-
-                # Include the raw llm output if requested
-                if gen_options and gen_options.llm_output:
-                    # Currently, we include the output from the generation LLM calls.
-                    for activated_rail in _log.activated_rails:
-                        if activated_rail.type == "generation":
-                            for executed_action in activated_rail.executed_actions:
-                                for llm_call in executed_action.llm_calls:
-                                    res.llm_output = llm_call.raw_response
-            else:
-                if gen_options and gen_options.output_vars:
-                    raise ValueError("The `output_vars` option is not supported for Colang 2.0 configurations.")
-
-                log_options = gen_options.log if gen_options else None
-                if log_options and (
-                    log_options.activated_rails
-                    or log_options.llm_calls
-                    or log_options.internal_events
-                    or log_options.colang_history
-                ):
-                    raise ValueError("The `log` option is not supported for Colang 2.0 configurations.")
-
-                if gen_options and gen_options.llm_output:
-                    raise ValueError("The `llm_output` option is not supported for Colang 2.0 configurations.")
-
-            # Include the state
-            if state is not None:
-                res.state = output_state
-
-            if self.config.tracing.enabled:
-                # TODO: move it to the top once resolved circular dependency of eval
-                # lazy import to avoid circular dependency
-                from nemoguardrails.tracing import Tracer
-
-                span_format = getattr(self.config.tracing, "span_format", "opentelemetry")
-                enable_content_capture = getattr(self.config.tracing, "enable_content_capture", False)
-                # Create a Tracer instance with instantiated adapters and span configuration
-                tracer = Tracer(
-                    input=messages,
-                    response=res,
-                    adapters=self._log_adapters,
-                    span_format=span_format,
-                    enable_content_capture=enable_content_capture,
-                )
-                await tracer.export_async()
-
-                # respect original log specification, if tracing added information to the output
-                if original_log_options:
-                    if not any(
-                        (
-                            original_log_options.internal_events,
-                            original_log_options.activated_rails,
-                            original_log_options.llm_calls,
-                            original_log_options.colang_history,
-                        )
-                    ):
-                        res.log = None
-                    else:
-                        # Ensure res.log exists before setting attributes
-                        if res.log is not None:
-                            if not original_log_options.internal_events:
-                                res.log.internal_events = []
-                            if not original_log_options.activated_rails:
-                                res.log.activated_rails = []
-                            if not original_log_options.llm_calls:
-                                res.log.llm_calls = []
-
-            return res
-        else:
-            # If a prompt is used, we only return the content of the message.
-
-            if reasoning_content:
-                thinking_trace = f"<think>{reasoning_content}</think>\n"
-                new_message["content"] = thinking_trace + new_message["content"]
-
-            if prompt:
-                return new_message["content"]
-            else:
-                if tool_calls:
-                    new_message["tool_calls"] = tool_calls
-                return new_message
-
-    def _validate_streaming_with_output_rails(self) -> None:
-        if len(self.config.rails.output.flows) > 0 and (
-            not self.config.rails.output.streaming or not self.config.rails.output.streaming.enabled
-        ):
-            raise StreamingNotSupportedError(
-                "stream_async() cannot be used when output rails are configured but "
-                "rails.output.streaming.enabled is False. Either set "
-                "rails.output.streaming.enabled to True in your configuration, or use "
-                "generate_async() instead of stream_async()."
-            )
+        finally:
+            await request_context.close()
 
     @overload
     def stream_async(
@@ -1262,89 +345,17 @@ class LLMRails:
         include_generation_metadata: Optional[bool] = None,
     ) -> AsyncIterator[Union[str, dict]]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
-
-        if include_generation_metadata is not None:
-            warnings.warn(
-                "include_generation_metadata is deprecated, use include_metadata instead. "
-                "It will be removed in version 0.22.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            include_metadata = include_generation_metadata
-
-        self._validate_streaming_with_output_rails()
-        self._validate_public_state(state)
-        # if an external generator is provided, use it directly
-        if generator:
-            if self.config.rails.output.streaming and self.config.rails.output.streaming.enabled:
-                return self._run_output_rails_in_streaming(
-                    streaming_handler=generator,
-                    output_rails_streaming_config=self.config.rails.output.streaming,
-                    messages=messages,
-                    prompt=prompt,
-                )
-            else:
-                return generator
-
-        self.explain_info = self._ensure_explain_info()
-
-        streaming_handler = StreamingHandler(include_metadata=include_metadata)
-
-        # Create a properly managed task with exception handling
-        async def _generation_task():
-            try:
-                await self.generate_async(
-                    prompt=prompt,
-                    messages=messages,
-                    streaming_handler=streaming_handler,
-                    options=options,
-                    state=state,
-                )
-            except Exception as e:
-                # If an exception occurs during generation, push it to the streaming handler as a json string
-                # This ensures the streaming pipeline is properly terminated
-                log.error(f"Error in generation task: {e}", exc_info=True)
-                error_message = str(e)
-                error_dict = extract_error_json(error_message)
-                error_payload = json.dumps(error_dict)
-                await streaming_handler.push_chunk(error_payload)
-                await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
-
-        task = asyncio.create_task(_generation_task())
-
-        # Store task reference to prevent garbage collection and ensure proper cleanup
-        if not hasattr(self, "_active_tasks"):
-            self._active_tasks = set()
-        self._active_tasks.add(task)
-
-        # Clean up task when it's done
-        def task_done_callback(task):
-            self._active_tasks.discard(task)
-
-        task.add_done_callback(task_done_callback)
-
-        # when we have output rails we wrap the streaming handler
-        # if len(self.config.rails.output.flows) > 0:
-        #
-        if self.config.rails.output.streaming and self.config.rails.output.streaming.enabled:
-            base_iterator = self._run_output_rails_in_streaming(
-                streaming_handler=streaming_handler,
-                output_rails_streaming_config=self.config.rails.output.streaming,
-                messages=messages,
-                prompt=prompt,
-            )
-        else:
-            base_iterator = streaming_handler
-
-        async def wrapped_iterator():
-            try:
-                async for chunk in base_iterator:
-                    if chunk is not None:
-                        yield chunk
-            finally:
-                await task
-
-        return wrapped_iterator()
+        validate_public_state(self.config, state)
+        return generation_token_stream(
+            self,
+            prompt=prompt,
+            messages=messages,
+            options=options,
+            state=state,
+            include_metadata=include_metadata,
+            generator=generator,
+            include_generation_metadata=include_generation_metadata,
+        )
 
     def generate(
         self,
@@ -1393,26 +404,7 @@ class LLMRails:
             The newly generate event(s).
 
         """
-        t0 = time.time()
-
-        # Initialize the LLM stats
-        llm_stats = LLMStats()
-        llm_stats_var.set(llm_stats)
-
-        # Compute the new events.
-        processing_log = []
-        new_events = await self.runtime.generate_events(events, processing_log=processing_log)
-
-        # If logging is enabled, we log the conversation
-        # TODO: add support for logging flag
-        if self.verbose:
-            history = get_colang_history(events)
-            log.info(f"Conversation history so far: \n{history}")
-
-        log.info("--- :: Total processing took %.2f seconds." % (time.time() - t0))
-        log.info("--- :: Stats: %s" % llm_stats)
-
-        return new_events
+        return await generate_colang_events(self, events)
 
     def generate_events(
         self,
@@ -1448,23 +440,13 @@ class LLMRails:
             (output_events, output_state) Returns a sequence of output events and an output
               state.
         """
-        t0 = time.time()
-        llm_stats = LLMStats()
-        llm_stats_var.set(llm_stats)
-
-        # Compute the new events.
-        # We need to protect 'process_events' to be called only once at a time
-        # TODO (cschueller): Why is this?
-        async with process_events_semaphore:
-            output_events, output_state = await self.runtime.process_events(events, state, blocking)
-
-        took = time.time() - t0
-        # Small tweak, disable this when there were no events (or it was just too fast).
-        if took > 0.1:
-            log.info("--- :: Total processing took %.2f seconds." % took)
-            log.info("--- :: Stats: %s" % llm_stats)
-
-        return output_events, output_state
+        return await process_colang_events(
+            self,
+            events,
+            state,
+            blocking,
+            semaphore=process_events_semaphore,
+        )
 
     def process_events(
         self,
@@ -1532,38 +514,7 @@ class LLMRails:
 
                 result = await rails.check_async(messages, rail_types=[RailType.INPUT])
         """
-        if rail_types is not None:
-            options: Optional[dict] = {"rails": [r.value for r in rail_types]}
-        else:
-            options = _determine_rails_from_messages(messages)
-
-        if options is None:
-            last_content = messages[-1].get("content", "") if messages else ""
-            return RailsResult(status=RailStatus.PASSED, content=last_content)
-
-        rails_to_run = options["rails"]
-        if "output" in rails_to_run:
-            original_content = _get_last_content_by_role(messages, "assistant")
-        else:
-            original_content = _get_last_content_by_role(messages, "user")
-
-        messages = _normalize_messages_for_rails(messages, rails_to_run)
-        options["log"] = {"activated_rails": True}
-
-        response = await self.generate_async(messages=messages, options=options)
-
-        if not isinstance(response, GenerationResponse):
-            raise RuntimeError(f"Expected GenerationResponse, got {type(response).__name__}")
-
-        blocking_rail = _get_blocking_rail(response)
-        result_content = _get_last_response_content(response)
-
-        if blocking_rail:
-            return RailsResult(status=RailStatus.BLOCKED, content=result_content, rail=blocking_rail)
-
-        if result_content != original_content:
-            return RailsResult(status=RailStatus.MODIFIED, content=result_content)
-        return RailsResult(status=RailStatus.PASSED, content=result_content)
+        return await rails_check.check_messages(self, messages, rail_types=rail_types)
 
     def check(
         self,
@@ -1590,22 +541,38 @@ class LLMRails:
         return loop.run_until_complete(self.check_async(messages, rail_types=rail_types))
 
     def register_action(self, action: Callable, name: Optional[str] = None) -> Self:
-        """Register a custom action for the rails configuration."""
+        """Register a custom action for the rails configuration.
+
+        This mutates the runtime action registry and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.register_action(action, name)
         return self
 
     def register_action_param(self, name: str, value: Any) -> Self:
-        """Registers a custom action parameter."""
+        """Register a custom action parameter.
+
+        This mutates runtime action dependencies and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.register_action_param(name, value)
         return self
 
     def register_filter(self, filter_fn: Callable, name: Optional[str] = None) -> Self:
-        """Register a custom filter for the rails configuration."""
+        """Register a custom filter for the rails configuration.
+
+        This mutates the runtime task manager and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.llm_task_manager.register_filter(filter_fn, name)
         return self
 
     def register_output_parser(self, output_parser: Callable, name: str) -> Self:
-        """Register a custom output parser for the rails configuration."""
+        """Register a custom output parser for the rails configuration.
+
+        This mutates the runtime task manager and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.llm_task_manager.register_output_parser(output_parser, name)
         return self
 
@@ -1614,6 +581,9 @@ class LLMRails:
 
         :name: The name of the variable or function that will be used.
         :value_or_fn: The value or function that will be used to generate the value.
+
+        This mutates the runtime task manager and is intended to be called
+        during application startup, before concurrent generation requests begin.
         """
         self.runtime.llm_task_manager.register_prompt_context(name, value_or_fn)
         return self
@@ -1624,9 +594,12 @@ class LLMRails:
         Args:
             name: The name of the embedding search provider that will be used.
             cls: The class that will be used to generate and search embedding
+
+        This updates the instance provider registry. Register providers during
+        startup so knowledge-base and generation-action setup can see them.
         """
 
-        self.embedding_search_providers[name] = cls
+        self.embedding_search.register_provider(name, cls)
         return self
 
     def register_embedding_provider(self, cls: Type[EmbeddingModel], name: Optional[str] = None) -> Self:
@@ -1639,14 +612,16 @@ class LLMRails:
         Raises:
             ValueError: If the engine name is not provided and the model does not have an engine name.
             ValueError: If the model does not have 'encode' or 'encode_async' methods.
+
+        This updates the process-global embedding provider registry and is
+        intended to be called during application startup.
         """
         register_embedding_provider(engine_name=name, model=cls)
         return self
 
     def explain(self) -> ExplainInfo:
         """Helper function to return the latest ExplainInfo object."""
-        if self.explain_info is None:
-            self.explain_info = self._ensure_explain_info()
+        self.explain_info = explain_info_for_current_context(self.explain_info)
         return self.explain_info
 
     def __getstate__(self):
@@ -1672,298 +647,12 @@ class LLMRails:
         2. Runs sequential (parallel for colang 2.0 in future) flows for each chunk.
         3. Yields the chunk if not blocked, or STOP if blocked.
         """
-
-        def _get_last_context_message(
-            messages: Optional[List[dict]] = None,
-        ) -> dict:
-            if messages is None:
-                return {}
-
-            for message in reversed(messages):
-                if message.get("role") == "context":
-                    return message
-            return {}
-
-        def _get_latest_user_message(
-            messages: Optional[List[dict]] = None,
-        ) -> dict:
-            if messages is None:
-                return {}
-            for message in reversed(messages):
-                if message.get("role") == "user":
-                    return message
-            return {}
-
-        def _prepare_context_for_parallel_rails(
-            chunk_str: str,
-            prompt: Optional[str] = None,
-            messages: Optional[List[dict]] = None,
-        ) -> dict:
-            """Prepare context for parallel rails execution."""
-            context_message = _get_last_context_message(messages)
-            user_message = prompt or _get_latest_user_message(messages)
-
-            context = {
-                "user_message": user_message,
-                "bot_message": chunk_str,
-            }
-
-            if context_message:
-                context.update(context_message["content"])
-
-            return context
-
-        def _create_events_for_chunk(chunk_str: str, context: dict) -> List[dict]:
-            """Create events for running output rails on a chunk."""
-            return [
-                {"type": "ContextUpdate", "data": context},
-                {"type": "BotMessage", "text": chunk_str},
-            ]
-
-        def _prepare_params(
-            flow_id: str,
-            action_name: str,
-            bot_response_chunk: str,
-            prompt: Optional[str] = None,
-            messages: Optional[List[dict]] = None,
-            action_params: Dict[str, Any] = {},
+        async for chunk in run_output_rails_in_streaming(
+            self,
+            streaming_handler=streaming_handler,
+            output_rails_streaming_config=output_rails_streaming_config,
+            prompt=prompt,
+            messages=messages,
+            stream_first=stream_first,
         ):
-            context_message = _get_last_context_message(messages)
-            user_message = prompt or _get_latest_user_message(messages)
-
-            context = {
-                "user_message": user_message,
-                "bot_message": bot_response_chunk,
-            }
-
-            if context_message:
-                context.update(context_message["content"])
-
-            model_name = flow_id.split("$")[-1].split("=")[-1].strip('"')
-
-            # we pass action params that are defined in the flow
-            # caveate, e.g. prmpt_security uses bot_response=$bot_message
-            # to resolve replace placeholders in action_params
-            for key, value in action_params.items():
-                if value == "$bot_message":
-                    action_params[key] = bot_response_chunk
-                elif value == "$user_message":
-                    action_params[key] = user_message
-
-            return {
-                # TODO:: are there other context variables that need to be passed?
-                # passing events to compute context was not successful
-                # context var failed due to different context
-                "context": context,
-                "llm_task_manager": self.runtime.llm_task_manager,
-                "config": self.config,
-                "model_name": model_name,
-                "llms": self.runtime.registered_action_params.get("llms", {}),
-                "llm": self.runtime.registered_action_params.get(f"{action_name}_llm", self.llm),
-                **action_params,
-            }
-
-        buffer_strategy = get_buffer_strategy(output_rails_streaming_config)
-        output_rails_flows_id = self.config.rails.output.flows
-        stream_first = stream_first or output_rails_streaming_config.stream_first
-        get_action_details = partial(get_action_details_from_flow_id, flows=self.config.flows)
-
-        parallel_mode = getattr(self.config.rails.output, "parallel", False)
-
-        async for chunk_batch in buffer_strategy(streaming_handler):
-            user_output_chunks = chunk_batch.user_output_chunks
-            # format processing_context for output rails processing (needs full context)
-            bot_response_chunk = buffer_strategy.format_chunks(chunk_batch.processing_context)
-
-            # check if user_output_chunks is a list of individual chunks
-            # or if it's a JSON string, by convention this means an error occurred and the error dict is stored as a JSON
-            if not isinstance(user_output_chunks, list):
-                try:
-                    json.loads(user_output_chunks)
-                    yield user_output_chunks
-                    return
-                except (json.JSONDecodeError, TypeError):
-                    # if it's not JSON, treat it as empty list
-                    user_output_chunks = []
-
-            if stream_first:
-                # yield the individual chunks directly from the buffer strategy
-                for chunk in user_output_chunks:
-                    yield chunk
-
-            if parallel_mode:
-                try:
-                    context = _prepare_context_for_parallel_rails(bot_response_chunk, prompt, messages)
-                    events = _create_events_for_chunk(bot_response_chunk, context)
-
-                    flows_with_params = {}
-                    for flow_id in output_rails_flows_id:
-                        action_name, action_params = get_action_details(flow_id)
-                        params = _prepare_params(
-                            flow_id=flow_id,
-                            action_name=action_name,
-                            bot_response_chunk=bot_response_chunk,
-                            prompt=prompt,
-                            messages=messages,
-                            action_params=action_params,
-                        )
-                        flows_with_params[flow_id] = {
-                            "action_name": action_name,
-                            "params": params,
-                        }
-
-                    result_tuple = await self.runtime.action_dispatcher.execute_action(
-                        "run_output_rails_in_parallel_streaming",
-                        {
-                            "flows_with_params": flows_with_params,
-                            "events": events,
-                        },
-                    )
-
-                    # ActionDispatcher.execute_action always returns (result, status)
-                    result, status = result_tuple
-
-                    if status != "success":
-                        log.error(f"Parallel rails execution failed with status: {status}")
-                        # continue processing the chunk even if rails fail
-                        pass
-                    else:
-                        # if there are any stop events, content was blocked or internal error occurred
-                        result_events = getattr(result, "events", None)
-                        if result_events:
-                            # extract the flow info from the first stop event
-                            stop_event = result_events[0]
-                            blocked_flow = stop_event.get("flow_id", "output rails")
-                            error_type = stop_event.get("error_type")
-
-                            if error_type == "internal_error":
-                                error_message = stop_event.get("error_message", "Unknown error")
-                                reason = f"Internal error in {blocked_flow} rail: {error_message}"
-                                error_code = "rail_execution_failure"
-                                error_type = "internal_error"
-                            else:
-                                reason = f"Blocked by {blocked_flow} rails."
-                                error_code = "content_blocked"
-                                error_type = "guardrails_violation"
-
-                            error_data = {
-                                "error": {
-                                    "message": reason,
-                                    "type": error_type,
-                                    "param": blocked_flow,
-                                    "code": error_code,
-                                }
-                            }
-                            yield json.dumps(error_data)
-                            return
-
-                except Exception as e:
-                    log.error(f"Error in parallel rail execution: {e}")
-                    # don't block the stream for rail execution errors
-                    # continue processing the chunk
-                    pass
-
-                # update explain info for parallel mode
-                self.explain_info = self._ensure_explain_info()
-
-            else:
-                for flow_id in output_rails_flows_id:
-                    action_name, action_params = get_action_details(flow_id)
-
-                    params = _prepare_params(
-                        flow_id=flow_id,
-                        action_name=action_name,
-                        bot_response_chunk=bot_response_chunk,
-                        prompt=prompt,
-                        messages=messages,
-                        action_params=action_params,
-                    )
-
-                    result = await self.runtime.action_dispatcher.execute_action(action_name, params)
-                    self.explain_info = self._ensure_explain_info()
-
-                    action_func = self.runtime.action_dispatcher.get_action(action_name)
-
-                    # Use the mapping to decide if the result indicates blocked content.
-                    if is_output_blocked(result, action_func):
-                        reason = f"Blocked by {flow_id} rails."
-
-                        # return the error as a plain JSON string (not in SSE format)
-                        # NOTE: When integrating with the OpenAI Python client, the server code should:
-                        # 1. detect this JSON error object in the stream
-                        # 2. terminate the stream
-                        # 3. format the error following OpenAI's SSE format
-                        # the OpenAI client will then properly raise an APIError with this error message
-
-                        error_data = {
-                            "error": {
-                                "message": reason,
-                                "type": "guardrails_violation",
-                                "param": flow_id,
-                                "code": "content_blocked",
-                            }
-                        }
-
-                        # return as plain JSON: the server should detect this JSON and convert it to an HTTP error
-                        yield json.dumps(error_data)
-                        return
-
-            if not stream_first:
-                # yield the individual chunks directly from the buffer strategy
-                for chunk in user_output_chunks:
-                    yield chunk
-
-
-def _determine_rails_from_messages(messages: List[dict]) -> Optional[dict]:
-    roles = {msg.get("role") for msg in reversed(messages)}
-    has_user = "user" in roles
-    has_assistant = "assistant" in roles
-
-    if not has_user and not has_assistant:
-        log.warning(
-            "check() called with no user or assistant messages. "
-            "Only system, context, or tool messages found. "
-            "Returning passing result without running rails."
-        )
-        return None
-
-    if has_user and has_assistant:
-        return {"rails": ["input", "output"]}
-    if has_user:
-        return {"rails": ["input"]}
-    return {"rails": ["output"]}
-
-
-def _normalize_messages_for_rails(
-    messages: List[dict],
-    rails: List[str],
-) -> List[dict]:
-    if rails == ["output"]:
-        has_user = any(msg.get("role") == "user" for msg in messages)
-        if not has_user:
-            return [{"role": "user", "content": ""}] + messages
-
-    return messages
-
-
-def _get_last_content_by_role(messages: List[dict], role: str) -> str:
-    for msg in reversed(messages):
-        if msg.get("role") == role:
-            return msg.get("content", "")
-    return ""
-
-
-def _get_blocking_rail(response: "GenerationResponse") -> Optional[str]:
-    if response.log and response.log.activated_rails:
-        for rail in response.log.activated_rails:
-            if rail.stop:
-                return rail.name
-    return None
-
-
-def _get_last_response_content(response: "GenerationResponse") -> str:
-    if isinstance(response.response, list) and response.response:
-        return response.response[-1].get("content", "")
-    if isinstance(response.response, str):
-        return response.response
-    return ""
+            yield chunk

--- a/nemoguardrails/rails/llm/runtime/colang_turns.py
+++ b/nemoguardrails/rails/llm/runtime/colang_turns.py
@@ -25,7 +25,6 @@ from typing import Any, List, Optional, Protocol, Tuple, Union, cast
 from nemoguardrails.actions.llm.utils import get_colang_history
 from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
-from nemoguardrails.colang.v2_x.runtime.serialization import state_to_json
 from nemoguardrails.context import llm_stats_var, streaming_handler_var
 from nemoguardrails.logging.stats import LLMStats
 from nemoguardrails.streaming import END_OF_STREAM
@@ -131,7 +130,7 @@ async def _run_colang_2_turn(
 
     return ColangTurnResult(
         new_events=new_events,
-        output_state={"state": state_to_json(output_state), "version": "2.x"},
+        output_state=None,
     )
 
 

--- a/tests/rails/llm/test_colang_turns.py
+++ b/tests/rails/llm/test_colang_turns.py
@@ -24,7 +24,6 @@ from nemoguardrails.context import llm_stats_var, streaming_handler_var
 from nemoguardrails.logging.stats import LLMStats
 from nemoguardrails.rails.llm import llmrails as llmrails_module
 from nemoguardrails.rails.llm.llmrails import LLMRails
-from nemoguardrails.rails.llm.runtime import colang_turns
 from nemoguardrails.rails.llm.runtime.colang_turns import (
     generate_colang_events,
     process_colang_events,
@@ -214,7 +213,7 @@ async def test_run_colang_turn_v1_streams_error_chunk_before_reraising():
 
 
 @pytest.mark.asyncio
-async def test_run_colang_turn_v2_processes_events_with_default_instant_actions(monkeypatch):
+async def test_run_colang_turn_v2_processes_events_with_default_instant_actions():
     output_state = object()
 
     class Runtime:
@@ -231,12 +230,6 @@ async def test_run_colang_turn_v2_processes_events_with_default_instant_actions(
                 }
             )
             return [{"type": "StartUtteranceBotAction", "script": "Hi"}], output_state
-
-    monkeypatch.setattr(
-        colang_turns,
-        "state_to_json",
-        lambda state: {"serialized": state is output_state},
-    )
 
     runtime = Runtime()
     turn_result = await run_colang_turn(
@@ -255,14 +248,11 @@ async def test_run_colang_turn_v2_processes_events_with_default_instant_actions(
         }
     ]
     assert turn_result.new_events == [{"type": "StartUtteranceBotAction", "script": "Hi"}]
-    assert turn_result.output_state == {
-        "state": {"serialized": True},
-        "version": "2.x",
-    }
+    assert turn_result.output_state is None
 
 
 @pytest.mark.asyncio
-async def test_run_colang_turn_v2_honors_configured_instant_actions(monkeypatch):
+async def test_run_colang_turn_v2_honors_configured_instant_actions():
     class Runtime:
         def __init__(self):
             self.instant_actions = None
@@ -270,8 +260,6 @@ async def test_run_colang_turn_v2_honors_configured_instant_actions(monkeypatch)
         async def process_events(self, events, state, instant_actions, blocking):
             self.instant_actions = instant_actions
             return [], object()
-
-    monkeypatch.setattr(colang_turns, "state_to_json", lambda state: {})
 
     runtime = Runtime()
     await run_colang_turn(

--- a/tests/rails/llm/test_llmrails_api_contract.py
+++ b/tests/rails/llm/test_llmrails_api_contract.py
@@ -18,6 +18,8 @@ import pickle
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.context import explain_info_var
+from nemoguardrails.logging.explain import ExplainInfo
 from tests.utils import FakeLLMModel
 
 
@@ -25,7 +27,7 @@ def _config() -> RailsConfig:
     return RailsConfig.from_content(config={"models": []})
 
 
-def test_constructor_keeps_public_state_visible():
+def test_constructor_keeps_public_compatibility_state_visible():
     config = _config()
     llm = FakeLLMModel(responses=[])
 
@@ -35,6 +37,7 @@ def test_constructor_keeps_public_state_visible():
     assert rails.llm is llm
     assert rails.runtime is not None
     assert rails.llm_generation_actions is not None
+    assert rails.embedding_search.providers == {}
     assert rails.events_history_cache == {}
     assert rails.explain_info is None
 
@@ -70,11 +73,25 @@ async def test_sync_wrappers_raise_when_called_from_async_loop():
 def test_getstate_serializes_config_only():
     rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
     rails.events_history_cache["cached"] = [{"type": "CachedEvent"}]
+    rails.explain_info = ExplainInfo()
     rails.register_action_param("custom_param", object())
 
     state = rails.__getstate__()
 
     assert state == {"config": rails.config}
+
+
+def test_explain_prefers_active_request_context_over_latest_instance_info():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+    latest_explain_info = ExplainInfo()
+    request_explain_info = ExplainInfo()
+    rails.explain_info = latest_explain_info
+    token = explain_info_var.set(request_explain_info)
+    try:
+        assert rails.explain() is request_explain_info
+        assert rails.explain_info is request_explain_info
+    finally:
+        explain_info_var.reset(token)
 
 
 def test_pickle_round_trip_reinitializes_from_config_without_runtime_state():

--- a/tests/rails/llm/test_llmrails_hardening.py
+++ b/tests/rails/llm/test_llmrails_hardening.py
@@ -1,0 +1,462 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+from copy import deepcopy
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.context import (
+    explain_info_var,
+    generation_options_var,
+    llm_stats_var,
+    raw_llm_request,
+    streaming_handler_var,
+)
+from nemoguardrails.logging.explain import ExplainInfo
+from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.rails.llm.config import Model
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
+from nemoguardrails.rails.llm.runtime.colang_turns import ColangTurnResult
+from nemoguardrails.streaming import END_OF_STREAM
+from tests.utils import FakeLLMModel
+
+COLANG = """
+define user express greeting
+  "hi"
+
+define flow
+  user express greeting
+  $user_greeted = True
+  bot express greeting
+
+define bot express greeting
+  "Hello there!"
+"""
+
+
+def _config(yaml_content: str | None = None) -> RailsConfig:
+    return RailsConfig.from_content(colang_content=COLANG, yaml_content=yaml_content)
+
+
+def _rails(config: RailsConfig | None = None) -> LLMRails:
+    return LLMRails(config=config or _config(), llm=FakeLLMModel(responses=["  express greeting"]))
+
+
+@pytest.mark.asyncio
+async def test_generate_standard_info_logs_keep_llmrails_logger_name(caplog):
+    with caplog.at_level(logging.INFO):
+        await _rails().generate_async(messages=[{"role": "user", "content": "hi"}])
+
+    total_processing_logs = [record for record in caplog.records if "--- :: Total processing took" in record.message]
+
+    assert [record.name for record in total_processing_logs] == ["nemoguardrails.rails.llm.llmrails"]
+
+
+@pytest.mark.asyncio
+async def test_generate_prompt_and_messages_return_shapes_without_options():
+    prompt_result = await _rails().generate_async(prompt="hi")
+    assert prompt_result == "Hello there!"
+
+    messages_result = await _rails().generate_async(messages=[{"role": "user", "content": "hi"}])
+    assert messages_result == {"role": "assistant", "content": "Hello there!"}
+
+
+@pytest.mark.asyncio
+async def test_generate_options_dict_and_object_return_generation_response():
+    dict_result = await _rails().generate_async(
+        prompt="hi",
+        options={"output_vars": ["user_greeted"]},
+    )
+
+    assert isinstance(dict_result, GenerationResponse)
+    assert dict_result.response == "Hello there!"
+    assert dict_result.output_data == {"user_greeted": True}
+
+    options = GenerationOptions(output_vars=["user_greeted"])
+    object_result = await _rails().generate_async(
+        messages=[{"role": "user", "content": "hi"}],
+        options=options,
+    )
+
+    assert isinstance(object_result, GenerationResponse)
+    assert object_result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert object_result.output_data == {"user_greeted": True}
+
+
+@pytest.mark.asyncio
+async def test_generate_state_forces_generation_response_without_options():
+    state = {"events": []}
+
+    result = await _rails().generate_async(
+        messages=[{"role": "user", "content": "hi"}],
+        state=state,
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert result.state is not None
+    assert "events" in result.state
+    assert state == {"events": []}
+
+
+@pytest.mark.asyncio
+async def test_generate_tracing_enabled_returns_generation_response_without_requested_log():
+    config = _config(
+        yaml_content="""
+tracing:
+  enabled: true
+  adapters: []
+"""
+    )
+
+    result = await _rails(config).generate_async(prompt="hi")
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == "Hello there!"
+    assert result.log is None
+
+
+@pytest.mark.asyncio
+async def test_generate_tracing_does_not_mutate_generation_options_object():
+    config = _config(
+        yaml_content="""
+tracing:
+  enabled: true
+  adapters: []
+"""
+    )
+    options = GenerationOptions()
+
+    result = await _rails(config).generate_async(prompt="hi", options=options)
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == "Hello there!"
+    assert result.log is None
+    assert options.log.activated_rails is False
+    assert options.log.llm_calls is False
+    assert options.log.internal_events is False
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_mutate_input_messages_or_options_dict():
+    messages = [{"role": "user", "content": "hi"}]
+    options = {
+        "rails": ["input", "output", "retrieval", "dialog", "tool_input", "tool_output"],
+        "output_vars": ["user_greeted"],
+    }
+    original_messages = deepcopy(messages)
+    original_options = deepcopy(options)
+
+    result = await _rails().generate_async(messages=messages, options=options)
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert messages == original_messages
+    assert options == original_options
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generate_requests_keep_context_isolated():
+    token_options = generation_options_var.set(None)
+    token_request = raw_llm_request.set(None)
+    snapshots = {}
+    both_requests_started = asyncio.Event()
+
+    async def fake_run_colang_turn(rails, events, state, processing_log):
+        request = cast(list[dict[str, Any]], deepcopy(raw_llm_request.get()))
+        options = cast(GenerationOptions, generation_options_var.get())
+        prompt = request[0]["content"]
+        snapshots[prompt] = {
+            "request": request,
+            "llm_params": deepcopy(options.llm_params),
+        }
+
+        if len(snapshots) == 2:
+            both_requests_started.set()
+
+        await both_requests_started.wait()
+        processing_log.extend(
+            [
+                {"type": "noop", "timestamp": 0.0},
+                {"type": "noop", "timestamp": 0.1},
+            ]
+        )
+        return ColangTurnResult(
+            new_events=[
+                {
+                    "type": "StartUtteranceBotAction",
+                    "script": f"reply {prompt}",
+                }
+            ],
+            output_state=None,
+        )
+
+    try:
+        rails = _rails()
+
+        with patch(
+            "nemoguardrails.rails.llm.generation.generation_workflow.run_colang_turn",
+            fake_run_colang_turn,
+        ):
+            first, second = await asyncio.gather(
+                rails.generate_async(
+                    prompt="first",
+                    options={"llm_params": {"request_id": "first"}},
+                ),
+                rails.generate_async(
+                    prompt="second",
+                    options={"llm_params": {"request_id": "second"}},
+                ),
+            )
+
+        first = cast(GenerationResponse, first)
+        second = cast(GenerationResponse, second)
+        assert first.response == "reply first"
+        assert second.response == "reply second"
+        assert snapshots == {
+            "first": {
+                "request": [{"role": "user", "content": "first"}],
+                "llm_params": {"request_id": "first"},
+            },
+            "second": {
+                "request": [{"role": "user", "content": "second"}],
+                "llm_params": {"request_id": "second"},
+            },
+        }
+        assert generation_options_var.get() is None
+        assert raw_llm_request.get() is None
+
+    finally:
+        generation_options_var.reset(token_options)
+        raw_llm_request.reset(token_request)
+
+
+@pytest.mark.asyncio
+async def test_generate_resets_request_context_after_success_in_same_task():
+    outer_options = GenerationOptions(llm_params={"request_id": "outer"})
+    outer_request = [{"role": "user", "content": "outer"}]
+    outer_explain_info = ExplainInfo()
+    outer_stats = LLMStats()
+    token_options = generation_options_var.set(outer_options)
+    token_request = raw_llm_request.set(outer_request)
+    token_explain_info = explain_info_var.set(outer_explain_info)
+    token_stats = llm_stats_var.set(outer_stats)
+    token_streaming_handler = streaming_handler_var.set(None)
+
+    try:
+        result = await _rails().generate_async(
+            prompt="hi",
+            options={"llm_params": {"request_id": "inner"}},
+        )
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == "Hello there!"
+        assert generation_options_var.get() is outer_options
+        assert raw_llm_request.get() is outer_request
+        assert explain_info_var.get() is outer_explain_info
+        assert llm_stats_var.get() is outer_stats
+        assert streaming_handler_var.get() is None
+    finally:
+        streaming_handler_var.reset(token_streaming_handler)
+        llm_stats_var.reset(token_stats)
+        explain_info_var.reset(token_explain_info)
+        raw_llm_request.reset(token_request)
+        generation_options_var.reset(token_options)
+
+
+@pytest.mark.asyncio
+async def test_generate_resets_request_context_after_failure_in_same_task():
+    outer_options = GenerationOptions(llm_params={"request_id": "outer"})
+    outer_request = [{"role": "user", "content": "outer"}]
+    outer_explain_info = ExplainInfo()
+    outer_stats = LLMStats()
+    token_options = generation_options_var.set(outer_options)
+    token_request = raw_llm_request.set(outer_request)
+    token_explain_info = explain_info_var.set(outer_explain_info)
+    token_stats = llm_stats_var.set(outer_stats)
+    token_streaming_handler = streaming_handler_var.set(None)
+
+    async def failing_run_colang_turn(rails, events, state, processing_log):
+        raise RuntimeError("generation failed")
+
+    try:
+        rails = _rails()
+        with patch(
+            "nemoguardrails.rails.llm.generation.generation_workflow.run_colang_turn",
+            failing_run_colang_turn,
+        ):
+            with pytest.raises(RuntimeError, match="generation failed"):
+                await rails.generate_async(
+                    prompt="hi",
+                    options={"llm_params": {"request_id": "inner"}},
+                )
+
+        assert generation_options_var.get() is outer_options
+        assert raw_llm_request.get() is outer_request
+        assert explain_info_var.get() is outer_explain_info
+        assert llm_stats_var.get() is outer_stats
+        assert streaming_handler_var.get() is None
+    finally:
+        streaming_handler_var.reset(token_streaming_handler)
+        llm_stats_var.reset(token_stats)
+        explain_info_var.reset(token_explain_info)
+        raw_llm_request.reset(token_request)
+        generation_options_var.reset(token_options)
+
+
+@pytest.mark.asyncio
+async def test_generate_closes_request_streaming_handler_once_on_success():
+    class StreamingHandler:
+        def __init__(self):
+            self.chunks = []
+
+        async def push_chunk(self, chunk):
+            self.chunks.append(chunk)
+
+    streaming_handler = StreamingHandler()
+
+    result = await _rails().generate_async(
+        prompt="hi",
+        streaming_handler=cast(Any, streaming_handler),
+    )
+
+    assert result == "Hello there!"
+    assert streaming_handler.chunks.count(END_OF_STREAM) == 1
+    assert streaming_handler.chunks[-1] is END_OF_STREAM
+
+
+@pytest.mark.asyncio
+async def test_generate_closes_request_streaming_handler_once_on_failure():
+    class StreamingHandler:
+        def __init__(self):
+            self.chunks = []
+
+        async def push_chunk(self, chunk):
+            self.chunks.append(chunk)
+
+    async def failing_run_colang_turn(rails, events, state, processing_log):
+        raise RuntimeError("generation failed")
+
+    streaming_handler = StreamingHandler()
+
+    with patch(
+        "nemoguardrails.rails.llm.generation.generation_workflow.run_colang_turn",
+        failing_run_colang_turn,
+    ):
+        with pytest.raises(RuntimeError, match="generation failed"):
+            await _rails().generate_async(
+                prompt="hi",
+                streaming_handler=cast(Any, streaming_handler),
+            )
+
+    assert streaming_handler.chunks == [END_OF_STREAM]
+
+
+@pytest.mark.asyncio
+async def test_generate_closes_request_streaming_handler_before_trace_export():
+    order = []
+
+    class StreamingHandler:
+        async def push_chunk(self, chunk):
+            if chunk is END_OF_STREAM:
+                order.append("stream-closed")
+
+    async def export_trace(**kwargs):
+        order.append("trace-exported")
+
+    config = _config(
+        yaml_content="""
+tracing:
+  enabled: true
+  adapters: []
+"""
+    )
+
+    with patch(
+        "nemoguardrails.rails.llm.generation.generation_workflow.export_generation_trace",
+        export_trace,
+    ):
+        result = await _rails(config).generate_async(
+            prompt="hi",
+            streaming_handler=cast(Any, StreamingHandler()),
+        )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == "Hello there!"
+    assert order == ["stream-closed", "trace-exported"]
+
+
+@pytest.mark.asyncio
+async def test_generate_colang_1_writes_implicit_history_cache_when_state_is_none():
+    rails = _rails()
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == {"role": "assistant", "content": "Hello there!"}
+    assert len(rails.events_history_cache) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_colang_1_does_not_write_implicit_history_cache_with_explicit_state():
+    rails = _rails()
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "hi"}],
+        state={"events": []},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert rails.events_history_cache == {}
+
+
+def test_env_api_key_model_kwargs_do_not_write_back_to_config(monkeypatch):
+    monkeypatch.setenv("NGR_TEST_API_KEY", "env-secret")
+    config = RailsConfig(
+        models=[
+            Model(
+                type="main",
+                engine="fake",
+                model="fake",
+                api_key_env_var="NGR_TEST_API_KEY",
+                parameters={"base_url": "https://example.test"},
+            )
+        ]
+    )
+
+    with patch("nemoguardrails.rails.llm.llmrails.init_llm_model") as init_llm:
+        init_llm.return_value = FakeLLMModel(responses=[])
+        LLMRails(config=config)
+
+    init_kwargs = init_llm.call_args.kwargs["kwargs"]
+    assert init_kwargs["api_key"] == "env-secret"
+    assert init_kwargs["base_url"] == "https://example.test"
+    assert config.models[0].parameters == {"base_url": "https://example.test"}
+
+
+def test_reused_rails_config_does_not_accumulate_prepared_flows():
+    config = _config()
+
+    LLMRails(config=config, llm=FakeLLMModel(responses=[]))
+    prepared_flow_count = len(config.flows)
+
+    LLMRails(config=config, llm=FakeLLMModel(responses=[]))
+
+    assert len(config.flows) == prepared_flow_count

--- a/tests/rails/llm/test_llmrails_startup_boundary.py
+++ b/tests/rails/llm/test_llmrails_startup_boundary.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import ModuleType, SimpleNamespace
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.rails.llm import llmrails
+from nemoguardrails.rails.llm.config import RailsConfig, TracingConfig
+from nemoguardrails.rails.llm.startup.config_preparation import PreparedLLMRailsConfig
+from nemoguardrails.rails.llm.startup.embedding_search import DEFAULT_EMBEDDING_ENGINE, DEFAULT_EMBEDDING_MODEL
+from nemoguardrails.rails.llm.startup.tracing import create_startup_tracing_adapters
+
+
+class RuntimeWithRegistries:
+    def __init__(self):
+        self.llm_task_manager = object()
+        self.registered_action_params = {}
+
+    def register_action_param(self, name, value):
+        self.registered_action_params[name] = value
+
+
+def _prepared_config(config: RailsConfig) -> PreparedLLMRailsConfig:
+    setattr(config, "_prepared_for_startup_test", True)
+    return PreparedLLMRailsConfig(
+        config=config,
+        default_embedding_model="prepared-model",
+        default_embedding_engine="prepared-engine",
+        default_embedding_params={"prepared": True},
+    )
+
+
+def test_constructor_startup_order_from_config_preparation_through_kb(monkeypatch):
+    sequence = []
+
+    def prepare_llmrails_config(**kwargs):
+        sequence.append("prepare config")
+        assert kwargs["default_embedding_model"] == DEFAULT_EMBEDDING_MODEL
+        assert kwargs["default_embedding_engine"] == DEFAULT_EMBEDDING_ENGINE
+        assert kwargs["default_embedding_params"] == {}
+        return _prepared_config(kwargs["config"])
+
+    def load_config_py_modules(config):
+        sequence.append("load config.py modules")
+        assert getattr(config, "_prepared_for_startup_test") is True
+        return [ModuleType("config")]
+
+    def runtime_for_colang_version(config, verbose):
+        sequence.append("runtime creation")
+        assert getattr(config, "_prepared_for_startup_test") is True
+        assert verbose is True
+        return RuntimeWithRegistries()
+
+    def run_config_py_init_hooks(rails, config_modules):
+        sequence.append("config.py init hooks")
+        assert len(config_modules) == 1
+        assert getattr(rails.config, "_prepared_for_startup_test") is True
+        assert isinstance(rails.runtime, RuntimeWithRegistries)
+
+    def create_log_adapters(tracing_config):
+        sequence.append("tracing adapter creation")
+        assert tracing_config.enabled is True
+        return ["adapter"]
+
+    def validate_config(config):
+        sequence.append("validation")
+
+    def init_llms(rails):
+        sequence.append("LLM/model-cache initialization")
+
+    def register_llm_generation_actions(rails, verbose):
+        sequence.append("generation-action registration")
+        assert verbose is True
+        rails.llm_generation_actions = object()
+
+    def init_knowledge_base(rails):
+        sequence.append("KB initialization")
+        rails.kb = None
+
+    monkeypatch.setattr(llmrails, "prepare_llmrails_config", prepare_llmrails_config)
+    monkeypatch.setattr(llmrails, "load_config_py_modules", load_config_py_modules)
+    monkeypatch.setattr(llmrails, "runtime_for_colang_version", runtime_for_colang_version)
+    monkeypatch.setattr(llmrails, "run_config_py_init_hooks", run_config_py_init_hooks)
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+    monkeypatch.setattr(llmrails, "validate_llmrails_config", validate_config)
+    monkeypatch.setattr(llmrails.LLMRails, "_init_llms", init_llms)
+    monkeypatch.setattr(llmrails, "register_llm_generation_actions", register_llm_generation_actions)
+    monkeypatch.setattr(llmrails, "init_knowledge_base", init_knowledge_base)
+
+    config = RailsConfig(models=[], tracing=TracingConfig(enabled=True))
+
+    rails = llmrails.LLMRails(config, verbose=True)
+
+    assert sequence == [
+        "prepare config",
+        "load config.py modules",
+        "runtime creation",
+        "config.py init hooks",
+        "tracing adapter creation",
+        "validation",
+        "LLM/model-cache initialization",
+        "generation-action registration",
+        "KB initialization",
+    ]
+    assert rails._log_adapters == ["adapter"]
+    assert rails.embedding_search.default_model == "prepared-model"
+    assert rails.embedding_search.default_engine == "prepared-engine"
+    assert rails.embedding_search.default_params == {"prepared": True}
+    assert rails.explain_info is None
+
+
+def test_config_py_hook_sees_prepared_state_and_provider_registration_reaches_later_startup(monkeypatch):
+    provider_seen_by_generation_actions = None
+    provider_seen_by_kb = None
+
+    class CustomProvider(EmbeddingsIndex):
+        pass
+
+    config_module = ModuleType("config")
+
+    def init(app):
+        assert getattr(app.config, "_prepared_for_startup_test") is True
+        assert isinstance(app.runtime, RuntimeWithRegistries)
+        assert app.embedding_search.default_model == "prepared-model"
+        assert app.embedding_search.default_engine == "prepared-engine"
+        assert app.embedding_search.default_params == {"prepared": True}
+        assert app.embedding_search.providers == {}
+        app.register_embedding_search_provider("custom", CustomProvider)
+
+    setattr(config_module, "init", init)
+
+    def register_llm_generation_actions(rails, verbose):
+        nonlocal provider_seen_by_generation_actions
+        del verbose
+        provider_seen_by_generation_actions = rails.embedding_search.providers["custom"]
+        rails.llm_generation_actions = SimpleNamespace()
+
+    def init_knowledge_base(rails):
+        nonlocal provider_seen_by_kb
+        provider_seen_by_kb = rails.embedding_search.providers["custom"]
+        rails.kb = None
+
+    monkeypatch.setattr(llmrails, "prepare_llmrails_config", lambda **kwargs: _prepared_config(kwargs["config"]))
+    monkeypatch.setattr(llmrails, "load_config_py_modules", lambda config: [config_module])
+    monkeypatch.setattr(llmrails, "runtime_for_colang_version", lambda config, verbose: RuntimeWithRegistries())
+    monkeypatch.setattr(llmrails, "validate_llmrails_config", lambda config: None)
+    monkeypatch.setattr(llmrails.LLMRails, "_init_llms", lambda rails: None)
+    monkeypatch.setattr(llmrails, "register_llm_generation_actions", register_llm_generation_actions)
+    monkeypatch.setattr(llmrails, "init_knowledge_base", init_knowledge_base)
+
+    config = RailsConfig(models=[])
+    object.__setattr__(config, "tracing", None)
+
+    rails = llmrails.LLMRails(config)
+
+    assert rails.embedding_search.providers["custom"] is CustomProvider
+    assert provider_seen_by_generation_actions is CustomProvider
+    assert provider_seen_by_kb is CustomProvider
+    assert rails._log_adapters is None
+
+
+def test_tracing_adapters_are_created_after_config_py_init_hooks(monkeypatch):
+    events = []
+    config_module = ModuleType("config")
+
+    def init(app):
+        app.tracing_marker = "hook-ran"
+        events.append("hook")
+
+    setattr(config_module, "init", init)
+
+    def create_log_adapters(tracing_config):
+        assert tracing_config.enabled is True
+        assert events == ["hook"]
+        events.append("tracing")
+        return [{"tracing": tracing_config}]
+
+    monkeypatch.setattr(llmrails, "prepare_llmrails_config", lambda **kwargs: _prepared_config(kwargs["config"]))
+    monkeypatch.setattr(llmrails, "load_config_py_modules", lambda config: [config_module])
+    monkeypatch.setattr(llmrails, "runtime_for_colang_version", lambda config, verbose: RuntimeWithRegistries())
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+    monkeypatch.setattr(llmrails, "validate_llmrails_config", lambda config: None)
+    monkeypatch.setattr(llmrails.LLMRails, "_init_llms", lambda rails: None)
+    monkeypatch.setattr(
+        llmrails,
+        "register_llm_generation_actions",
+        lambda rails, verbose: setattr(rails, "llm_generation_actions", object()),
+    )
+    monkeypatch.setattr(llmrails, "init_knowledge_base", lambda rails: setattr(rails, "kb", None))
+
+    config = RailsConfig(models=[], tracing=TracingConfig(enabled=True))
+
+    rails = llmrails.LLMRails(config)
+
+    assert events == ["hook", "tracing"]
+    assert getattr(rails, "tracing_marker") == "hook-ran"
+    assert rails._log_adapters == [{"tracing": config.tracing}]
+
+
+def test_startup_tracing_helper_returns_none_without_tracing_config(monkeypatch):
+    calls = []
+
+    def create_log_adapters(tracing_config):
+        calls.append(tracing_config)
+        return ["adapter"]
+
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+
+    config = RailsConfig(models=[])
+    object.__setattr__(config, "tracing", None)
+
+    assert create_startup_tracing_adapters(config) is None
+    assert calls == []
+
+
+def test_startup_tracing_helper_creates_adapters_when_tracing_config_is_present(monkeypatch):
+    calls = []
+
+    def create_log_adapters(tracing_config):
+        calls.append(tracing_config)
+        return ["adapter"]
+
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+
+    config = RailsConfig(models=[], tracing=TracingConfig(enabled=True))
+
+    assert create_startup_tracing_adapters(config) == ["adapter"]
+    assert calls == [config.tracing]

--- a/tests/rails/llm/test_rails_check.py
+++ b/tests/rails/llm/test_rails_check.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemoguardrails.rails.llm.checks.rails_check import check_messages
+from nemoguardrails.rails.llm.options import (
+    ActivatedRail,
+    GenerationLog,
+    GenerationResponse,
+    RailStatus,
+    RailType,
+)
+
+
+class FakeRails:
+    def __init__(self, response):
+        self.config = SimpleNamespace(colang_version="1.0")
+        self.runtime = SimpleNamespace()
+        self.response = response
+        self.generate_calls = []
+
+    async def generate_async(self, *, messages, options):
+        self.generate_calls.append({"messages": messages, "options": options})
+        return self.response
+
+
+class MutatingRails(FakeRails):
+    async def generate_async(self, *, messages, options):
+        messages[0]["content"]["nested"] = "changed"
+        return await super().generate_async(messages=messages, options=options)
+
+
+@pytest.mark.asyncio
+async def test_check_messages_detects_input_rails_and_marks_passed():
+    rails = FakeRails(GenerationResponse(response=[{"role": "user", "content": "hello"}]))
+
+    result = await check_messages(rails, [{"role": "user", "content": "hello"}])
+
+    assert result.status == RailStatus.PASSED
+    assert result.content == "hello"
+    assert rails.generate_calls == [
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {
+                "rails": ["input"],
+                "log": {"activated_rails": True},
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_messages_normalizes_output_only_messages():
+    rails = FakeRails(GenerationResponse(response=[{"role": "assistant", "content": "hello"}]))
+
+    result = await check_messages(rails, [{"role": "assistant", "content": "hello"}])
+
+    assert result.status == RailStatus.PASSED
+    assert rails.generate_calls[0]["messages"] == [
+        {"role": "user", "content": ""},
+        {"role": "assistant", "content": "hello"},
+    ]
+    assert rails.generate_calls[0]["options"]["rails"] == ["output"]
+
+
+@pytest.mark.asyncio
+async def test_check_messages_honors_explicit_rail_types_and_reports_modified_content():
+    rails = FakeRails(GenerationResponse(response=[{"role": "assistant", "content": "updated"}]))
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "original"},
+    ]
+
+    result = await check_messages(rails, messages, rail_types=[RailType.OUTPUT])
+
+    assert result.status == RailStatus.MODIFIED
+    assert result.content == "updated"
+    assert rails.generate_calls[0]["messages"] == messages
+    assert rails.generate_calls[0]["options"]["rails"] == ["output"]
+
+
+@pytest.mark.asyncio
+async def test_check_messages_does_not_expose_caller_messages_to_generation_mutation():
+    rails = MutatingRails(GenerationResponse(response=[{"role": "user", "content": "hello"}]))
+    messages = [
+        {"role": "context", "content": {"nested": "original"}},
+        {"role": "user", "content": "hello"},
+    ]
+
+    result = await check_messages(rails, messages)
+
+    assert result.status == RailStatus.PASSED
+    assert messages == [
+        {"role": "context", "content": {"nested": "original"}},
+        {"role": "user", "content": "hello"},
+    ]
+    assert rails.generate_calls[0]["messages"][0]["content"] == {"nested": "changed"}
+
+
+@pytest.mark.asyncio
+async def test_check_messages_reports_first_blocking_rail():
+    rails = FakeRails(
+        GenerationResponse(
+            response="blocked",
+            log=GenerationLog(
+                activated_rails=[
+                    ActivatedRail(type="input", name="first rail", stop=False),
+                    ActivatedRail(type="output", name="blocking rail", stop=True),
+                ]
+            ),
+        )
+    )
+
+    result = await check_messages(rails, [{"role": "user", "content": "hello"}])
+
+    assert result.status == RailStatus.BLOCKED
+    assert result.content == "blocked"
+    assert result.rail == "blocking rail"
+
+
+@pytest.mark.asyncio
+async def test_check_messages_rejects_unexpected_generation_response_type():
+    rails = FakeRails("not a generation response")
+
+    with pytest.raises(RuntimeError, match="Expected GenerationResponse, got str"):
+        await check_messages(rails, [{"role": "user", "content": "hello"}])

--- a/tests/test_configs/with_custom_embedding_search_provider/config.py
+++ b/tests/test_configs/with_custom_embedding_search_provider/config.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
+from typing import List, Optional
 
 from nemoguardrails import LLMRails
 from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
@@ -39,7 +39,7 @@ class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
         """Adds multiple items to the index."""
         self.items.extend(items)
 
-    async def search(self, text: str, max_results: int) -> List[IndexItem]:
+    async def search(self, text: str, max_results: int, threshold: Optional[float] = None) -> List[IndexItem]:
         """Searches the index for the closes matches to the provided text."""
         results = []
         for item in self.items:

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -18,7 +18,7 @@ import logging
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
-from nemoguardrails.rails.llm.llmrails import (
+from nemoguardrails.rails.llm.checks.rails_check import (
     _determine_rails_from_messages,
     _get_blocking_rail,
     _get_last_content_by_role,
@@ -535,6 +535,130 @@ class TestCheckAsyncExplicitRails:
         ]
         result = mock_rails.check(messages, rail_types=None)
         assert result.status == RailStatus.BLOCKED
+
+
+@pytest.fixture
+def colang_2_check_rails():
+    config = RailsConfig.from_content(
+        colang_content="""
+        import core
+        import guardrails
+
+        flow input rails $input_text
+          global $user_message
+          if $input_text == "block input"
+            bot refuse to respond
+            abort
+          if $input_text == "modify input"
+            $user_message = "modified input"
+
+        flow output rails $output_text
+          global $bot_message
+          if $output_text == "block output"
+            bot refuse to respond
+            abort
+          if $output_text == "modify output"
+            $bot_message = "modified output"
+
+        flow main
+          bot say "main flow should not run during check"
+        """,
+        yaml_content="""
+        colang_version: "2.x"
+        models: []
+        """,
+    )
+    return LLMRails(config)
+
+
+class TestColang2CheckAsync:
+    @pytest.mark.asyncio
+    async def test_input_only_passes_without_log_options(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "user", "content": "hello"}],
+            rail_types=[RailType.INPUT],
+        )
+
+        assert result.status == RailStatus.PASSED
+        assert result.content == "hello"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_input_only_modified(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "user", "content": "modify input"}],
+            rail_types=[RailType.INPUT],
+        )
+
+        assert result.status == RailStatus.MODIFIED
+        assert result.content == "modified input"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_input_only_blocked_reports_rail_category(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "user", "content": "block input"}],
+            rail_types=[RailType.INPUT],
+        )
+
+        assert result.status == RailStatus.BLOCKED
+        assert result.content == "I'm sorry, I can't respond to that."
+        assert result.rail == "input rails"
+
+    @pytest.mark.asyncio
+    async def test_output_only_passes_without_log_options(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "assistant", "content": "hello"}],
+            rail_types=[RailType.OUTPUT],
+        )
+
+        assert result.status == RailStatus.PASSED
+        assert result.content == "hello"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_output_only_modified(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "assistant", "content": "modify output"}],
+            rail_types=[RailType.OUTPUT],
+        )
+
+        assert result.status == RailStatus.MODIFIED
+        assert result.content == "modified output"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_output_only_blocked_reports_rail_category(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "assistant", "content": "block output"}],
+            rail_types=[RailType.OUTPUT],
+        )
+
+        assert result.status == RailStatus.BLOCKED
+        assert result.content == "I'm sorry, I can't respond to that."
+        assert result.rail == "output rails"
+
+    @pytest.mark.asyncio
+    async def test_auto_detects_input_and_output(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "safe output"},
+            ],
+        )
+
+        assert result.status == RailStatus.PASSED
+        assert result.content == "safe output"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_run_main_flow(self, colang_2_check_rails):
+        result = await colang_2_check_rails.check_async(
+            [{"role": "user", "content": "hello"}],
+            rail_types=[RailType.INPUT],
+        )
+
+        assert result.content != "main flow should not run during check"
 
 
 @pytest.fixture

--- a/tests/test_system_message_conversion.py
+++ b/tests/test_system_message_conversion.py
@@ -16,6 +16,7 @@
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.rails.llm.conversation.conversation_events import events_for_messages
 from tests.utils import FakeLLMModel
 
 
@@ -44,7 +45,7 @@ async def test_system_message_conversion_v1():
         {"role": "user", "content": "Hello!"},
     ]
 
-    events = llm_rails._get_events_for_messages(messages, None)
+    events = events_for_messages(llm_rails, messages, None)
 
     system_messages = [event for event in events if event["type"] == "SystemMessage"]
     assert len(system_messages) == 1
@@ -76,7 +77,7 @@ async def test_system_message_conversion_v2x():
         {"role": "user", "content": "Hello!"},
     ]
 
-    events = llm_rails._get_events_for_messages(messages, None)
+    events = events_for_messages(llm_rails, messages, None)
 
     system_messages = [event for event in events if event["type"] == "SystemMessage"]
     assert len(system_messages) == 1
@@ -108,7 +109,7 @@ async def test_system_message_conversion_multiple():
         {"role": "user", "content": "Hello!"},
     ]
 
-    events = llm_rails._get_events_for_messages(messages, None)
+    events = events_for_messages(llm_rails, messages, None)
 
     system_messages = [event for event in events if event["type"] == "SystemMessage"]
     assert len(system_messages) == 2

--- a/tests/test_token_usage_integration.py
+++ b/tests/test_token_usage_integration.py
@@ -25,7 +25,6 @@ Note about token usage testing:
 import pytest
 
 from nemoguardrails import RailsConfig
-from nemoguardrails.context import llm_stats_var
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from tests.utils import TestChat
 
@@ -284,12 +283,15 @@ async def test_token_usage_not_set_for_unsupported_provider():
         token_usage=token_usage_data,
     )
 
-    result = await chat.app.generate_async(messages=[{"role": "user", "content": "Hi!"}])
+    # Read the per-call stats from the response log rather than the request-scoped
+    # llm_stats_var contextvar, which generation_context now resets on request close.
+    result = await chat.app.generate_async(
+        messages=[{"role": "user", "content": "Hi!"}],
+        options={"log": {"llm_calls": True}},
+    )
 
-    assert result["content"] == "Hello there!"
+    assert result.response[-1]["content"] == "Hello there!"
 
-    llm_stats = llm_stats_var.get()
-
-    assert llm_stats is not None
-    assert llm_stats.get_stat("total_tokens") == 0
-    assert llm_stats.get_stat("total_calls") == 1
+    assert result.log is not None
+    assert result.log.stats.llm_calls_total_tokens == 0
+    assert result.log.stats.llm_calls_count == 1


### PR DESCRIPTION
## Summary

Moves `check_async` planning and result classification into the checks package, and wires the `LLMRails` public shell to the extracted domains.

## Why

At this point, the startup, runtime, conversation, generation, and streaming helpers already exist in earlier PRs. This final PR makes `LLMRails` the thin compatibility shell around those domains.

## What Changed

- Adds the checks package for rail planning and response classification.
- Updates `LLMRails` to delegate to the extracted startup, runtime, conversation, generation, streaming, and checks helpers.
- Removes obsolete private helper coupling from tests.
- Adds hardening and API contract tests for the final shell.
- Documents the explain-info behavior change in the migration notes.

## Review Notes

This is the main integration PR. The central review question is whether delegation preserves the existing public behavior:

- public method signatures and sync wrappers,
- constructor ordering,
- runtime/action registration behavior,
- return shapes,
- request-scoped explain info,
- streaming cleanup and error behavior,
- check API behavior.

## Stack Position

Part 8 of 8.

- Previous: #26
- Next: none, final stack PR

## Stack Context

This PR is part of an 8-PR stack that decomposes `LLMRails` internals while keeping `LLMRails` as the public compatibility surface.

Please review each PR against its parent branch, not directly against `develop`, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #20 | `stack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #21 | `stack/llmrails-02-startup-config-colang` | `stack/llmrails-01-public-contract-tests` |
| 3 | #22 | `stack/llmrails-03-startup-models-kb-actions` | `stack/llmrails-02-startup-config-colang` |
| 4 | #23 | `stack/llmrails-04-runtime-conversation` | `stack/llmrails-03-startup-models-kb-actions` |
| 5 | #24 | `stack/llmrails-05-generation-helpers` | `stack/llmrails-04-runtime-conversation` |
| 6 | #25 | `stack/llmrails-06-generation-workflow` | `stack/llmrails-05-generation-helpers` |
| 7 | #26 | `stack/llmrails-07-streaming` | `stack/llmrails-06-generation-workflow` |
| 8 | #27 | `stack/llmrails-08-checks` | `stack/llmrails-07-streaming` |

## Validation

Stack validation run on `stack/llmrails-08-checks`:

```text
poetry run pytest tests/rails/llm tests/test_llmrails_check_async.py tests/test_system_message_conversion.py tests/test_token_usage_integration.py -q
293 passed in 19.21s
```
