### PR TITLE
feat(benchmark): add Annoy migration benchmarks

### DIFF
--- a/benchmark/embedding_backend/README.md
+++ b/benchmark/embedding_backend/README.md
@@ -1,0 +1,123 @@
+# Embedding-backend benchmark
+
+`bench_embedding_backend.py` compares embedding nearest-neighbor backends for the
+default `BasicEmbeddingsIndex`:
+
+- **`numpy`** — exact cosine search over an L2-normalized matrix (the current default).
+- **`annoy`** — the previous default (approximate, `metric=angular`, `n_trees=10`),
+  benchmarked only if `annoy` is installed (it is no longer a project dependency).
+
+It provides reproducible benchmark evidence for replacing Annoy with exact NumPy
+search as the default backend. It is not a user migration guide: existing default
+knowledge-base caches are regenerated automatically, and threshold semantics are
+preserved by the implementation.
+
+## What it measures
+
+For each `N` (number of indexed vectors) and each backend:
+
+| Metric | Meaning |
+|---|---|
+| `build (ms)` | time to construct the index from precomputed embeddings |
+| `search p50 / p95 (ms)` | per-query latency percentiles over `--queries` random queries |
+| `recall@1`, `recall@k` | fraction of the **exact** cosine top-k that the backend returns |
+| `mem (MB)` | best-effort resident-set delta during build (Linux `/proc`) |
+
+**Methodology.** Both backends receive *identical* L2-normalized float32 vectors, so the
+embedding model is held constant and only the index varies. Ground truth is the exact
+cosine top-k computed with a full matrix product. `recall@k` therefore measures a backend's
+*approximation loss* against the exact answer — the NumPy backend is exact, so its recall is
+1.0 by construction; Annoy's recall reflects what its `n_trees=10` configuration gives up.
+
+The vectors are deterministic (fixed `--seed`) and lightly clustered so neighborhoods are
+non-trivial. Absolute recall depends on the data distribution; the exact backend is 1.0
+regardless.
+
+## Prerequisites
+
+Run inside the project's Poetry environment:
+
+```bash
+poetry install --with dev
+```
+
+> **Note (Annoy native build).** Annoy is a C++ extension. On a machine without a prebuilt
+> wheel, installing it requires a compiler and the Python headers, e.g. on Debian/Ubuntu:
+>
+> ```bash
+> sudo apt-get install -y g++ python3-dev
+> ```
+>
+> This native build requirement is one of the reasons Annoy was dropped. The NumPy backend
+> has no such requirement.
+
+## Running
+
+```bash
+# Default sweep: N = 100, 1k, 10k, 100k
+poetry run python benchmark/embedding_backend/bench_embedding_backend.py
+
+# Quick subset
+poetry run python benchmark/embedding_backend/bench_embedding_backend.py --sizes 100 1000 --queries 100
+
+# Flags
+#   --sizes    list of index sizes (default: 100 1000 10000 100000)
+#   --dim      embedding dimension (default: 384, = all-MiniLM-L6-v2)
+#   --k        neighbors to retrieve (default: 20, = BasicEmbeddingsIndex.search default)
+#   --queries  number of query vectors timed (default: 200)
+#   --seed     RNG seed for reproducibility (default: 1234)
+```
+
+### Reproducing the Annoy baseline comparison
+
+Annoy is no longer installed by default. To reproduce the head-to-head numbers below,
+install it into the environment first (needs the compiler/headers noted above):
+
+```bash
+poetry run python -m pip install annoy
+poetry run python benchmark/embedding_backend/bench_embedding_backend.py
+```
+
+If `annoy` is not importable, the script automatically runs the NumPy backend only and
+prints a note.
+
+## Results
+
+Captured with `dim=384, k=20, queries=200, seed=1234`; Annoy `metric=angular, n_trees=10`
+(matching `nemoguardrails/embeddings/basic.py` before the change). Hardware: aarch64
+macOS.
+
+| N | backend | build (ms) | search p50 (ms) | search p95 (ms) | recall@1 | recall@20 | mem (MB) |
+|---|---|---|---|---|---|---|---|
+| 100 | annoy | 8.6811 | 0.0575 | 0.1071 | 1.000 | 1.000 | 0.1 |
+| 100 | **numpy** | 0.1234 | 0.0076 | 0.0405 | **1.000** | **1.000** | 0.0 |
+| 1 000 | annoy | 70.0227 | 0.1042 | 0.2154 | 0.540 | 0.576 | 0.1 |
+| 1 000 | **numpy** | 0.0040 | 0.0398 | 0.0654 | **1.000** | **1.000** | 0.0 |
+| 10 000 | annoy | 447.7411 | 0.1492 | 0.2289 | 0.440 | 0.425 | 0.9 |
+| 10 000 | **numpy** | 0.0045 | 0.3406 | 1.2310 | **1.000** | **1.000** | 0.0 |
+| 100 000 | annoy | 4398.0658 | 0.1594 | 0.2320 | 0.090 | 0.083 | 58.7 |
+| 100 000 | **numpy** | 0.0037 | 2.9445 | 8.0138 | **1.000** | **1.000** | 0.0 |
+
+(`build` for NumPy is sub-microsecond because the embedding matrix is already a
+contiguous float32 array, so `build()` is effectively a no-op copy; the 0.12 ms at N=100 is
+first-call warm-up. `mem` is a best-effort RSS delta and under-reports the NumPy matrix,
+which is analytically `N · dim · 4` bytes ≈ 146 MB at N=100k , still well within budget and
+freed when the index is dropped.)
+
+### Conclusion
+
+- **Accuracy.** With the previous `n_trees=10`, Annoy's `recall@1` falls from 1.0 (N=100) to
+  **0.09 at N=100k** — it returns the true nearest neighbor only ~9% of the time at scale.
+  Exact NumPy is 1.0 everywhere. For a component that decides *which guardrail fires*, exact
+  retrieval is the safer default.
+- **Latency.** NumPy is faster at N ≤ 1 000, sub-millisecond and competitive at 10k, and only
+  slower at 100k — where Annoy's "win" is hollow because its answers are mostly wrong at that
+  recall.
+- **Build.** NumPy build is effectively free; Annoy grows to ~4.5 s at 100k.
+- **Crossover.** Exact search wins up to roughly the 10k-100k range; NeMo Guardrails'
+  default indexes sit well below that. For genuinely large indexes, a dedicated opt-in ANN
+  provider would be the right path instead of adding Annoy back to the default install.
+
+> Numbers vary with hardware and data distribution; re-run locally to get figures for your
+> environment. The qualitative result — exact NumPy keeps or improves quality and is
+> competitive-to-faster below the crossover — is robust.

--- a/benchmark/embedding_backend/README.md
+++ b/benchmark/embedding_backend/README.md
@@ -71,10 +71,11 @@ poetry run python benchmark/embedding_backend/bench_embedding_backend.py --sizes
 ### Reproducing the Annoy baseline comparison
 
 Annoy is no longer installed by default. To reproduce the head-to-head numbers below,
-install it into the environment first (needs the compiler/headers noted above):
+install the previous dependency version into the environment first (needs the
+compiler/headers noted above):
 
 ```bash
-poetry run python -m pip install annoy
+ANNOY_COMPILER_ARGS="-DANNOYLIB_MULTITHREADED_BUILD" poetry run python -m pip install --no-cache-dir --no-binary=:all: "annoy==1.17.3"
 poetry run python benchmark/embedding_backend/bench_embedding_backend.py
 ```
 
@@ -83,37 +84,39 @@ prints a note.
 
 ## Results
 
-Captured with `dim=384, k=20, queries=200, seed=1234`; Annoy `metric=angular, n_trees=10`
-(matching `nemoguardrails/embeddings/basic.py` before the change). Hardware: aarch64
-macOS.
+Representative run captured with `dim=384, k=20, queries=200, seed=1234`; Annoy
+`metric=angular, n_trees=10` (matching `nemoguardrails/embeddings/basic.py` before
+the change).
 
 | N | backend | build (ms) | search p50 (ms) | search p95 (ms) | recall@1 | recall@20 | mem (MB) |
 |---|---|---|---|---|---|---|---|
-| 100 | annoy | 8.6811 | 0.0575 | 0.1071 | 1.000 | 1.000 | 0.1 |
-| 100 | **numpy** | 0.1234 | 0.0076 | 0.0405 | **1.000** | **1.000** | 0.0 |
-| 1 000 | annoy | 70.0227 | 0.1042 | 0.2154 | 0.540 | 0.576 | 0.1 |
-| 1 000 | **numpy** | 0.0040 | 0.0398 | 0.0654 | **1.000** | **1.000** | 0.0 |
-| 10 000 | annoy | 447.7411 | 0.1492 | 0.2289 | 0.440 | 0.425 | 0.9 |
-| 10 000 | **numpy** | 0.0045 | 0.3406 | 1.2310 | **1.000** | **1.000** | 0.0 |
-| 100 000 | annoy | 4398.0658 | 0.1594 | 0.2320 | 0.090 | 0.083 | 58.7 |
-| 100 000 | **numpy** | 0.0037 | 2.9445 | 8.0138 | **1.000** | **1.000** | 0.0 |
+| 100 | annoy | 1.8980 | 0.0381 | 0.0434 | 1.000 | 1.000 | 0.0 |
+| 100 | **numpy** | 0.0033 | 0.0069 | 0.0076 | **1.000** | **1.000** | 0.0 |
+| 1 000 | annoy | 18.7925 | 0.0699 | 0.0824 | 0.480 | 0.526 | 0.0 |
+| 1 000 | **numpy** | 0.0028 | 0.0215 | 0.0257 | **1.000** | **1.000** | 0.0 |
+| 10 000 | annoy | 197.1430 | 0.0787 | 0.1308 | 0.510 | 0.445 | 0.0 |
+| 10 000 | **numpy** | 0.0022 | 0.1466 | 0.1962 | **1.000** | **1.000** | 0.0 |
+| 100 000 | annoy | 2206.5025 | 0.1196 | 0.1886 | 0.060 | 0.066 | 0.0 |
+| 100 000 | **numpy** | 0.0021 | 2.2650 | 2.7545 | **1.000** | **1.000** | 0.0 |
 
-(`build` for NumPy is sub-microsecond because the embedding matrix is already a
-contiguous float32 array, so `build()` is effectively a no-op copy; the 0.12 ms at N=100 is
-first-call warm-up. `mem` is a best-effort RSS delta and under-reports the NumPy matrix,
-which is analytically `N · dim · 4` bytes ≈ 146 MB at N=100k , still well within budget and
-freed when the index is dropped.)
+(`build` for NumPy measures the index-construction step after embeddings are already
+available and normalized. In this harness that is a contiguous float32 matrix handoff;
+the production `BasicEmbeddingsIndex.build()` also converts and normalizes the embeddings
+before storing the matrix. `mem` is a best-effort Linux RSS delta; on platforms without
+`/proc`, including macOS, the script reports `0.0`. The NumPy matrix size is analytically
+`N · dim · 4` bytes ≈ 146 MB at N=100k and is freed when the index is dropped.)
 
 ### Conclusion
 
 - **Accuracy.** With the previous `n_trees=10`, Annoy's `recall@1` falls from 1.0 (N=100) to
-  **0.09 at N=100k** — it returns the true nearest neighbor only ~9% of the time at scale.
+  **0.06 at N=100k** — it returns the true nearest neighbor only ~6% of the time at scale.
   Exact NumPy is 1.0 everywhere. For a component that decides *which guardrail fires*, exact
   retrieval is the safer default.
 - **Latency.** NumPy is faster at N ≤ 1 000, sub-millisecond and competitive at 10k, and only
   slower at 100k — where Annoy's "win" is hollow because its answers are mostly wrong at that
   recall.
-- **Build.** NumPy build is effectively free; Annoy grows to ~4.5 s at 100k.
+- **Build.** NumPy index construction over precomputed vectors is effectively free; Annoy
+  grows past 2 s at 100k in this run.
 - **Crossover.** Exact search wins up to roughly the 10k-100k range; NeMo Guardrails'
   default indexes sit well below that. For genuinely large indexes, a dedicated opt-in ANN
   provider would be the right path instead of adding Annoy back to the default install.

--- a/benchmark/embedding_backend/bench_embedding_backend.py
+++ b/benchmark/embedding_backend/bench_embedding_backend.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark harness: Annoy (current default) vs. exact NumPy cosine search.
+
+This measures the *index* layer in isolation (build / search / recall), feeding
+both backends identical pre-computed, L2-normalized vectors so the embedding
+model is held constant and only the nearest-neighbor backend varies.
+
+It records the Annoy baseline and reports:
+  - retrieval recall@k vs. exact-cosine ground truth
+  - search latency p50 / p95
+  - build time
+  - index memory (best-effort RSS delta)
+
+Run:
+    poetry run python benchmark/embedding_backend/bench_embedding_backend.py
+    poetry run python benchmark/embedding_backend/bench_embedding_backend.py --sizes 100 1000 --queries 100
+
+Notes on equivalence:
+  Annoy "angular" distance is monotonic with cosine similarity for normalized vectors.
+  Therefore Annoy's exact ranking would match cosine ranking; recall@k below measures
+  Annoy's approximation loss against the exact answer. The NumPy backend computes exact
+  cosine, so its recall is 1.0 by construction.
+"""
+
+import argparse
+import gc
+import statistics
+import time
+from typing import Callable, List, Tuple
+
+import numpy as np
+
+SearchFn = Callable[[np.ndarray, int], List[int]]
+BuildResult = Tuple[float, SearchFn, float]
+
+# Parameters matching the current default in nemoguardrails/embeddings/basic.py
+ANNOY_METRIC = "angular"
+ANNOY_N_TREES = 10
+DEFAULT_DIM = 384  # all-MiniLM-L6-v2
+DEFAULT_K = 20  # BasicEmbeddingsIndex.search default max_results
+
+
+def _rss_mb() -> float:
+    """Best-effort resident-set-size in MB (Linux /proc, else 0)."""
+    try:
+        with open("/proc/self/statm") as f:
+            pages = int(f.read().split()[1])  # resident pages
+        return pages * 4096 / (1024 * 1024)
+    except Exception:
+        return 0.0
+
+
+def make_normalized_vectors(n: int, dim: int, seed: int) -> np.ndarray:
+    """Deterministic, L2-normalized float32 vectors (clustered, embedding-like)."""
+    rng = np.random.default_rng(seed)
+    # A handful of cluster centers + noise so neighborhoods are non-trivial
+    n_clusters = max(1, min(50, n // 20))
+    centers = rng.standard_normal((n_clusters, dim)).astype(np.float32)
+    assign = rng.integers(0, n_clusters, size=n)
+    vecs = centers[assign] + 0.35 * rng.standard_normal((n, dim)).astype(np.float32)
+    norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return (vecs / norms).astype(np.float32)
+
+
+def exact_topk(matrix: np.ndarray, queries: np.ndarray, k: int) -> np.ndarray:
+    """Ground-truth exact cosine top-k indices, shape (Q, k), best-first."""
+    sims = queries @ matrix.T  # (Q, N) cosine, inputs already normalized
+    # argpartition for top-k, then sort those k by score desc
+    part = np.argpartition(-sims, kth=min(k, sims.shape[1] - 1), axis=1)[:, :k]
+    rows = np.arange(sims.shape[0])[:, None]
+    order = np.argsort(-sims[rows, part], axis=1)
+    return part[rows, order]
+
+
+def recall_at_k(approx: List[List[int]], truth: np.ndarray, k: int) -> float:
+    """Mean fraction of the exact top-k recovered by the approximate backend."""
+    total = 0.0
+    for i, got in enumerate(approx):
+        gold = set(truth[i, :k].tolist())
+        if not gold:
+            continue
+        total += len(gold.intersection(got[:k])) / len(gold)
+    return total / len(approx)
+
+
+def annoy_available() -> bool:
+    try:
+        import annoy  # type: ignore  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def build_annoy(matrix: np.ndarray) -> BuildResult:
+    """Build an Annoy index and return build time, search callback, and memory delta."""
+    from annoy import AnnoyIndex  # type: ignore
+
+    n, dim = matrix.shape
+    gc.collect()
+    mem_before = _rss_mb()
+    t0 = time.perf_counter()
+    index = AnnoyIndex(dim, ANNOY_METRIC)
+    for i in range(n):
+        index.add_item(i, matrix[i])
+    index.build(ANNOY_N_TREES)
+    build_s = time.perf_counter() - t0
+    mem_delta = _rss_mb() - mem_before
+
+    def search(q: np.ndarray, k: int) -> List[int]:
+        idxs, _dists = index.get_nns_by_vector(q, k, include_distances=True)
+        return idxs
+
+    return build_s, search, mem_delta
+
+
+def build_numpy(matrix: np.ndarray) -> BuildResult:
+    """Build a NumPy exact-search index and return build time, search callback, and memory delta."""
+    gc.collect()
+    mem_before = _rss_mb()
+    t0 = time.perf_counter()
+    # Vectors are already normalized; store a contiguous float32 matrix.
+    mat = np.ascontiguousarray(matrix, dtype=np.float32)
+    build_s = time.perf_counter() - t0
+    mem_delta = _rss_mb() - mem_before
+
+    def search(q: np.ndarray, k: int) -> List[int]:
+        sims = mat @ q  # (N,) cosine similarity
+        kk = min(k, sims.shape[0])
+        part = np.argpartition(-sims, kth=kk - 1)[:kk]
+        return part[np.argsort(-sims[part])].tolist()
+
+    return build_s, search, mem_delta
+
+
+# Annoy is no longer a dependency. Install it explicitly to reproduce the
+# baseline comparison; otherwise only the NumPy backend runs.
+BACKENDS = {"numpy": build_numpy}
+if annoy_available():
+    BACKENDS = {"annoy": build_annoy, "numpy": build_numpy}
+
+
+def time_searches(search_fn: SearchFn, queries: np.ndarray, k: int) -> Tuple[List[List[int]], float, float, float]:
+    """Run each query individually; return (results, p50_ms, p95_ms, mean_ms)."""
+    latencies: List[float] = []
+    results: List[List[int]] = []
+    for q in queries:
+        t0 = time.perf_counter()
+        res = search_fn(q, k)
+        latencies.append((time.perf_counter() - t0) * 1000.0)
+        results.append(res)
+    latencies.sort()
+    p50 = statistics.median(latencies)
+    p95 = latencies[min(len(latencies) - 1, int(round(0.95 * (len(latencies) - 1))))]
+    mean = statistics.fmean(latencies)
+    return results, p50, p95, mean
+
+
+def run(sizes: List[int], dim: int, k: int, n_queries: int, seed: int) -> List[dict]:
+    rows: List[dict] = []
+    for n in sizes:
+        matrix = make_normalized_vectors(n, dim, seed=seed)
+        queries = make_normalized_vectors(n_queries, dim, seed=seed + 1)
+        truth = exact_topk(matrix, queries, k)
+
+        for name, builder in BACKENDS.items():
+            build_s, search_fn, mem_mb = builder(matrix)
+            # warm-up
+            search_fn(queries[0], k)
+            results, p50, p95, mean = time_searches(search_fn, queries, k)
+            rec1 = recall_at_k(results, truth, 1)
+            rec5 = recall_at_k(results, truth, 5)
+            reck = recall_at_k(results, truth, k)
+            rows.append(
+                dict(
+                    n=n,
+                    backend=name,
+                    build_ms=build_s * 1000.0,
+                    p50_ms=p50,
+                    p95_ms=p95,
+                    mean_ms=mean,
+                    recall_1=rec1,
+                    recall_5=rec5,
+                    recall_k=reck,
+                    mem_mb=mem_mb,
+                )
+            )
+            print(
+                f"  N={n:<7} {name:<6} build={build_s * 1000:11.4f}ms "
+                f"p50={p50:9.4f}ms p95={p95:9.4f}ms "
+                f"recall@1={rec1:.3f} recall@{k}={reck:.3f} mem~{mem_mb:6.1f}MB"
+            )
+    return rows
+
+
+def print_markdown(rows: List[dict], k: int) -> None:
+    print("\n### Results (dim={}, k={})\n".format(DEFAULT_DIM, k))
+    print(f"| N | backend | build (ms) | search p50 (ms) | search p95 (ms) | recall@1 | recall@{k} | mem (MB) |")
+    print("|---|---|---|---|---|---|---|---|")
+    for r in rows:
+        print(
+            f"| {r['n']} | {r['backend']} | {r['build_ms']:.4f} | {r['p50_ms']:.4f} | "
+            f"{r['p95_ms']:.4f} | {r['recall_1']:.3f} | {r['recall_k']:.3f} | {r['mem_mb']:.1f} |"
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sizes", type=int, nargs="+", default=[100, 1000, 10000, 100000])
+    ap.add_argument("--dim", type=int, default=DEFAULT_DIM)
+    ap.add_argument("--k", type=int, default=DEFAULT_K)
+    ap.add_argument("--queries", type=int, default=200)
+    ap.add_argument("--seed", type=int, default=1234)
+    args = ap.parse_args()
+
+    print(
+        f"Embedding backend benchmark | dim={args.dim} k={args.k} queries={args.queries} "
+        f"seed={args.seed}\nbackends: {', '.join(BACKENDS)}\n"
+        + (
+            f"Annoy: metric={ANNOY_METRIC} n_trees={ANNOY_N_TREES}\n"
+            if "annoy" in BACKENDS
+            else "Annoy not installed -- run `poetry run python -m pip install annoy` to reproduce the baseline comparison.\n"
+        )
+    )
+    rows = run(args.sizes, args.dim, args.k, args.queries, args.seed)
+    print_markdown(rows, args.k)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/embedding_backend/bench_embedding_backend.py
+++ b/benchmark/embedding_backend/bench_embedding_backend.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Benchmark harness: Annoy (current default) vs. exact NumPy cosine search.
+"""Benchmark harness: Annoy (previous default) vs. exact NumPy cosine search.
 
 This measures the *index* layer in isolation (build / search / recall), feeding
 both backends identical pre-computed, L2-normalized vectors so the embedding
@@ -47,7 +47,7 @@ import numpy as np
 SearchFn = Callable[[np.ndarray, int], List[int]]
 BuildResult = Tuple[float, SearchFn, float]
 
-# Parameters matching the current default in nemoguardrails/embeddings/basic.py
+# Parameters matching the previous default in nemoguardrails/embeddings/basic.py
 ANNOY_METRIC = "angular"
 ANNOY_N_TREES = 10
 DEFAULT_DIM = 384  # all-MiniLM-L6-v2
@@ -89,6 +89,8 @@ def exact_topk(matrix: np.ndarray, queries: np.ndarray, k: int) -> np.ndarray:
 
 def recall_at_k(approx: List[List[int]], truth: np.ndarray, k: int) -> float:
     """Mean fraction of the exact top-k recovered by the approximate backend."""
+    if not approx:
+        return 0.0
     total = 0.0
     for i, got in enumerate(approx):
         gold = set(truth[i, :k].tolist())
@@ -123,7 +125,7 @@ def build_annoy(matrix: np.ndarray) -> BuildResult:
     mem_delta = _rss_mb() - mem_before
 
     def search(q: np.ndarray, k: int) -> List[int]:
-        idxs, _dists = index.get_nns_by_vector(q, k, include_distances=True)
+        idxs, _dists = index.get_nns_by_vector(q, n=k, include_distances=True)
         return idxs
 
     return build_s, search, mem_delta
@@ -184,7 +186,6 @@ def run(sizes: List[int], dim: int, k: int, n_queries: int, seed: int) -> List[d
             search_fn(queries[0], k)
             results, p50, p95, mean = time_searches(search_fn, queries, k)
             rec1 = recall_at_k(results, truth, 1)
-            rec5 = recall_at_k(results, truth, 5)
             reck = recall_at_k(results, truth, k)
             rows.append(
                 dict(
@@ -195,7 +196,6 @@ def run(sizes: List[int], dim: int, k: int, n_queries: int, seed: int) -> List[d
                     p95_ms=p95,
                     mean_ms=mean,
                     recall_1=rec1,
-                    recall_5=rec5,
                     recall_k=reck,
                     mem_mb=mem_mb,
                 )
@@ -208,8 +208,8 @@ def run(sizes: List[int], dim: int, k: int, n_queries: int, seed: int) -> List[d
     return rows
 
 
-def print_markdown(rows: List[dict], k: int) -> None:
-    print("\n### Results (dim={}, k={})\n".format(DEFAULT_DIM, k))
+def print_markdown(rows: List[dict], k: int, dim: int = DEFAULT_DIM) -> None:
+    print("\n### Results (dim={}, k={})\n".format(dim, k))
     print(f"| N | backend | build (ms) | search p50 (ms) | search p95 (ms) | recall@1 | recall@{k} | mem (MB) |")
     print("|---|---|---|---|---|---|---|---|")
     for r in rows:
@@ -238,7 +238,7 @@ def main() -> None:
         )
     )
     rows = run(args.sizes, args.dim, args.k, args.queries, args.seed)
-    print_markdown(rows, args.k)
+    print_markdown(rows, args.k, args.dim)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds benchmark tooling and reproduction notes used to compare the previous Annoy backend with the new exact NumPy backend.

## What Changed

- Adds a benchmark harness for build time, search latency, recall, and memory.
- Adds benchmark methodology, reproduction notes, and captured baseline results.

## Stack

Part 2 of 2.

- Base: `drop-annoy-feature`
- Head: `drop-annoy-benchmark`
- Previous: https://github.com/Pouyanpi/NeMo-Guardrails/pull/29

Review this PR against `drop-annoy-feature`; the implementation change is in the parent PR.

## Validation

```text
poetry run python benchmark/embedding_backend/bench_embedding_backend.py --sizes 100 --queries 5
passed, NumPy-only smoke run
```
