### PR TITLE
fix: avoid IORails sync generate coroutine warning

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -269,6 +269,15 @@ class IORails:
         if sync_config.metrics is not None:
             sync_config.metrics.enabled = False
 
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "IORails.generate() cannot be called from a running event loop. Use generate_async() instead."
+            )
+
         async def _run_sync_iorails():
             """Spin up a short-lived IORails engine for one synchronous generate call."""
             # Avoid counting this sync-API bridge as a separate user-created IORails instance.

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -16,6 +16,8 @@
 """Unit tests for iorails module."""
 
 import asyncio
+import gc
+import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -685,8 +687,17 @@ class TestGenerate:
         async def call_generate():
             iorails.generate([{"role": "user", "content": "hi"}])
 
-        with pytest.raises(RuntimeError):
-            asyncio.run(call_generate())
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            warnings.simplefilter("always")
+
+            with pytest.raises(RuntimeError, match="cannot be called from a running event loop"):
+                asyncio.run(call_generate())
+
+            gc.collect()
+
+        assert not [
+            warning for warning in recorded_warnings if issubclass(warning.category, RuntimeWarning)
+        ]
 
 
 class TestRefusalMessage:


### PR DESCRIPTION
## Summary

Fix `IORails.generate()` so calling the synchronous API from inside an already-running event loop fails cleanly without leaking an unawaited coroutine warning.

## Reproduction

On the current behavior, the focused test passes but emits a runtime warning:

```bash
poetry run pytest tests/guardrails/test_iorails.py::TestGenerate::test_generate_raises_when_called_from_async_loop -q -W always::RuntimeWarning
```

The warning appears as:

```text
RuntimeWarning: coroutine 'IORails.generate.<locals>._run_sync_iorails' was never awaited
```

In a larger test run, it can surface from pytest internals, for example:

```text
.../site-packages/_pytest/logging.py:351: RuntimeWarning: coroutine 'IORails.generate.<locals>._run_sync_iorails' was never awaited
  def __enter__(self) -> _HandlerType:
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

## Fix

`IORails.generate()` now checks for a running event loop before constructing the internal coroutine. If called from async code, it raises the existing `RuntimeError` path cleanly and tells callers to use `generate_async()`.

The test now also asserts that this path does not emit a `RuntimeWarning`.

## Validation

```bash
poetry run pytest tests/guardrails/test_iorails.py::TestGenerate -q
```
