### PR TITLE
fix(llmrails): load library files deterministically (2/5)

### DIFF
--- a/nemoguardrails/llm/prompts.py
+++ b/nemoguardrails/llm/prompts.py
@@ -41,6 +41,8 @@ def _load_prompts() -> List[TaskPrompt]:
 
     for path in prompts_dirs:
         for root, dirs, files in os.walk(path):
+            dirs.sort()
+            files.sort()
             for filename in files:
                 if filename.endswith(".yml") or filename.endswith(".yaml"):
                     with open(os.path.join(root, filename), encoding="utf-8") as prompts_file:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -318,9 +318,13 @@ class LLMRails(BaseGuardrails):
             self.config.flows.extend(default_flows)
 
             # We also need to load the content from the components library.
+            # Sort entries so the traversal order is filesystem-independent;
+            # otherwise the order in which library bot_messages are inserted
+            # (and which definition wins on collisions) varies between platforms.
             library_path = os.path.join(os.path.dirname(__file__), "../../library")
             for root, dirs, files in os.walk(library_path):
-                for file in files:
+                dirs.sort()
+                for file in sorted(files):
                     # Extract the full path for the file
                     full_path = os.path.join(root, file)
                     if file.endswith(".co"):

--- a/tests/test_prompt_override.py
+++ b/tests/test_prompt_override.py
@@ -16,6 +16,7 @@
 import os
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.llm import prompts as prompts_module
 from nemoguardrails.llm.prompts import get_prompt
 from nemoguardrails.llm.types import Task
 
@@ -28,3 +29,18 @@ def test_custom_llm_registration():
     prompt = get_prompt(config, Task.GENERATE_USER_INTENT)
 
     assert prompt.content == "<<This is a placeholder for a custom prompt for generating the user intent>>"
+
+
+def test_load_prompts_sorts_files_for_deterministic_overrides(tmp_path, monkeypatch):
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    (prompts_dir / "z.yml").write_text("prompts:\n- task: generate_user_intent\n  content: z\n", encoding="utf-8")
+    (prompts_dir / "a.yml").write_text("prompts:\n- task: generate_user_intent\n  content: a\n", encoding="utf-8")
+
+    def walk(_path):
+        yield str(prompts_dir), [], ["z.yml", "a.yml"]
+
+    monkeypatch.setattr(prompts_module, "CURRENT_DIR", str(tmp_path))
+    monkeypatch.setattr(prompts_module.os, "walk", walk)
+
+    assert [prompt.content for prompt in prompts_module._load_prompts()] == ["a", "z"]

--- a/tests/test_prompt_override.py
+++ b/tests/test_prompt_override.py
@@ -42,5 +42,6 @@ def test_load_prompts_sorts_files_for_deterministic_overrides(tmp_path, monkeypa
 
     monkeypatch.setattr(prompts_module, "CURRENT_DIR", str(tmp_path))
     monkeypatch.setattr(prompts_module.os, "walk", walk)
+    monkeypatch.delenv("PROMPTS_DIR", raising=False)
 
     assert [prompt.content for prompt in prompts_module._load_prompts()] == ["a", "z"]


### PR DESCRIPTION
## Summary

Sorts library traversal during LLMRails initialization so recorded rail tests do not depend on filesystem walk order.

## Why

Recorded tests expose that library bot message insertion order can vary across platforms when files are loaded in filesystem order.

## What Changed

- Sorts directories during library os.walk traversal.
- Sorts .co files before loading them.

## Review Notes

This is the only runtime change in the stack.

## Stack Position

Part 2 of 5.

- Previous: #33
- Next: #35

## Stack Context

This stack decomposes recorded end-to-end replay coverage into reviewable slices. The PRs should be reviewed against their parent branch in the stack.

Please review each PR against its parent branch, not directly against the root base branch, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #33 | `stack/recorded-tests-01-harness` | `stack/recorded-tests-base` |
| 2 | #34 | `stack/recorded-tests-02-deterministic-library-load` | `stack/recorded-tests-01-harness` |
| 3 | #35 | `stack/recorded-tests-03-clients` | `stack/recorded-tests-02-deterministic-library-load` |
| 4 | #36 | `stack/recorded-tests-04-public-api` | `stack/recorded-tests-03-clients` |
| 5 | #37 | `stack/recorded-tests-05-library-rails` | `stack/recorded-tests-04-public-api` |

## Validation

```text
poetry check --lock
poetry lock --no-update
poetry install --with dev
poetry run pytest tests/recorded --block-network -q
pre-commit hooks passed during commit creation
```
