### PR TITLE
fix(llmrails): track deferred startup and streaming followups (7/7)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -263,6 +263,7 @@ Use Case Diagrams <reference/use-case-diagrams.md>
 Python API <reference/python-api/index>
 CLI <reference/cli/index>
 Guardrails API Server Endpoints <reference/api-server-endpoints/index>
+Migrating to 0.23 <migration/0.23>
 Migrating to 0.22 <migration/0.22>
 ```
 

--- a/docs/migration/0.23.md
+++ b/docs/migration/0.23.md
@@ -1,0 +1,14 @@
+---
+myst:
+  html_meta:
+    page: "Migrating to 0.23"
+    nav: "Migrating to 0.23"
+description: Behavior changes to account for when updating a working NeMo Guardrails configuration to 0.23.
+keywords: ["nemoguardrails 0.23", "migration", "LLMRails", "explain"]
+---
+
+# Migrating to v0.23.0
+
+## Behavior Changes
+
+- `LLMRails.explain().llm_calls` now reflects only the most recent `generate`/`generate_async` call instead of accumulating across calls on a reused `LLMRails` instance. This matches the documented "latest call" contract and is a side effect of per-request context isolation in the decomposed generation pipeline.

--- a/nemoguardrails/rails/llm/checks/__init__.py
+++ b/nemoguardrails/rails/llm/checks/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []

--- a/nemoguardrails/rails/llm/checks/rails_check.py
+++ b/nemoguardrails/rails/llm/checks/rails_check.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Message rail check helpers."""
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, List, Optional, Protocol
+
+from nemoguardrails.rails.llm.options import (
+    GenerationResponse,
+    RailsResult,
+    RailStatus,
+    RailType,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = ["RailsCheckRuntime", "check_messages"]
+
+
+class RailsCheckRuntime(Protocol):
+    config: Any
+    runtime: Any
+
+    async def generate_async(
+        self,
+        *,
+        messages: List[dict],
+        options: dict,
+    ) -> object: ...
+
+
+@dataclass
+class RailsCheckPlan:
+    messages: List[dict]
+    options: dict
+    original_content: str
+
+
+async def check_messages(
+    rails: RailsCheckRuntime,
+    messages: List[dict],
+    rail_types: Optional[List[RailType]] = None,
+) -> RailsResult:
+    """Run input/output rails for a message list and return rail check status."""
+    plan = _plan_rails_check(messages, rail_types)
+    if plan is None:
+        last_content = messages[-1].get("content", "") if messages else ""
+        return RailsResult(status=RailStatus.PASSED, content=last_content)
+
+    response = await rails.generate_async(messages=plan.messages, options=plan.options)
+
+    if not isinstance(response, GenerationResponse):
+        raise RuntimeError(f"Expected GenerationResponse, got {type(response).__name__}")
+
+    return _classify_rails_response(response, plan.original_content)
+
+
+def _plan_rails_check(
+    messages: List[dict],
+    rail_types: Optional[List[RailType]] = None,
+) -> Optional[RailsCheckPlan]:
+    if rail_types is not None:
+        options: Optional[dict] = {"rails": [r.value for r in rail_types]}
+    else:
+        options = _determine_rails_from_messages(messages)
+
+    if options is None:
+        return None
+
+    rails_to_run = options["rails"]
+    if "output" in rails_to_run:
+        original_content = _get_last_content_by_role(messages, "assistant")
+    else:
+        original_content = _get_last_content_by_role(messages, "user")
+
+    messages = _normalize_messages_for_rails(deepcopy(messages), rails_to_run)
+    options["log"] = {"activated_rails": True}
+
+    return RailsCheckPlan(
+        messages=messages,
+        options=options,
+        original_content=original_content,
+    )
+
+
+def _classify_rails_response(
+    response: GenerationResponse,
+    original_content: str,
+) -> RailsResult:
+    blocking_rail = _get_blocking_rail(response)
+    result_content = _get_last_response_content(response)
+
+    if blocking_rail:
+        return RailsResult(status=RailStatus.BLOCKED, content=result_content, rail=blocking_rail)
+
+    if result_content != original_content:
+        return RailsResult(status=RailStatus.MODIFIED, content=result_content)
+    return RailsResult(status=RailStatus.PASSED, content=result_content)
+
+
+def _determine_rails_from_messages(messages: List[dict]) -> Optional[dict]:
+    roles = {msg.get("role") for msg in reversed(messages)}
+    has_user = "user" in roles
+    has_assistant = "assistant" in roles
+
+    if not has_user and not has_assistant:
+        log.warning(
+            "check() called with no user or assistant messages. "
+            "Only system, context, or tool messages found. "
+            "Returning passing result without running rails."
+        )
+        return None
+
+    if has_user and has_assistant:
+        return {"rails": ["input", "output"]}
+    if has_user:
+        return {"rails": ["input"]}
+    return {"rails": ["output"]}
+
+
+def _normalize_messages_for_rails(
+    messages: List[dict],
+    rails: List[str],
+) -> List[dict]:
+    if rails == ["output"]:
+        has_user = any(msg.get("role") == "user" for msg in messages)
+        if not has_user:
+            return [{"role": "user", "content": ""}] + messages
+
+    return messages
+
+
+def _get_last_content_by_role(messages: List[dict], role: str) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == role:
+            return msg.get("content", "")
+    return ""
+
+
+def _get_blocking_rail(response: GenerationResponse) -> Optional[str]:
+    if response.log and response.log.activated_rails:
+        for rail in response.log.activated_rails:
+            if rail.stop:
+                return rail.name
+    return None
+
+
+def _get_last_response_content(response: GenerationResponse) -> str:
+    if isinstance(response.response, list) and response.response:
+        return response.response[-1].get("content", "")
+    if isinstance(response.response, str):
+        return response.response
+    return ""

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -15,11 +15,8 @@
 
 """LLM Rails entry point."""
 
-import asyncio
-import json
 import logging
 import warnings
-from functools import partial
 from typing import (
     Any,
     AsyncIterator,
@@ -36,19 +33,16 @@ from typing import (
 
 from typing_extensions import Self
 
-from nemoguardrails.actions.output_mapping import is_output_blocked
 from nemoguardrails.base_guardrails import BaseGuardrails
 from nemoguardrails.colang.v1_0.runtime.runtime import Runtime
 from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.embeddings.index import EmbeddingsIndex
 from nemoguardrails.embeddings.providers import register_embedding_provider
 from nemoguardrails.embeddings.providers.base import EmbeddingModel
-from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.llm.models.initializer import init_llm_model
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.logging.verbose import set_verbose
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
-from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import (
     OutputRailsStreamingConfig,
     RailsConfig,
@@ -90,15 +84,11 @@ from nemoguardrails.rails.llm.startup.llm_action_models import (
     sync_update_llm_bindings,
 )
 from nemoguardrails.rails.llm.startup.tracing import create_startup_tracing_adapters
-from nemoguardrails.rails.llm.utils import (
-    get_action_details_from_flow_id,
-)
-from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
+from nemoguardrails.rails.llm.streaming.generation_stream import generation_token_stream
+from nemoguardrails.rails.llm.streaming.streaming_output_rails import run_output_rails_in_streaming
+from nemoguardrails.streaming import StreamingHandler
 from nemoguardrails.types import LLMModel
-from nemoguardrails.utils import (
-    extract_error_json,
-    get_or_create_event_loop,
-)
+from nemoguardrails.utils import get_or_create_event_loop
 
 log = logging.getLogger(__name__)
 
@@ -460,17 +450,6 @@ class LLMRails(BaseGuardrails):
         finally:
             await request_context.close()
 
-    def _validate_streaming_with_output_rails(self) -> None:
-        if len(self.config.rails.output.flows) > 0 and (
-            not self.config.rails.output.streaming or not self.config.rails.output.streaming.enabled
-        ):
-            raise StreamingNotSupportedError(
-                "stream_async() cannot be used when output rails are configured but "
-                "rails.output.streaming.enabled is False. Either set "
-                "rails.output.streaming.enabled to True in your configuration, or use "
-                "generate_async() instead of stream_async()."
-            )
-
     @overload
     def stream_async(
         self,
@@ -506,89 +485,17 @@ class LLMRails(BaseGuardrails):
         include_generation_metadata: Optional[bool] = None,
     ) -> AsyncIterator[Union[str, dict]]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
-
-        if include_generation_metadata is not None:
-            warnings.warn(
-                "include_generation_metadata is deprecated, use include_metadata instead. "
-                "It will be removed in version 0.22.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            include_metadata = include_generation_metadata
-
-        self._validate_streaming_with_output_rails()
-        self._validate_public_state(state)
-        # if an external generator is provided, use it directly
-        if generator:
-            if self.config.rails.output.streaming and self.config.rails.output.streaming.enabled:
-                return self._run_output_rails_in_streaming(
-                    streaming_handler=generator,
-                    output_rails_streaming_config=self.config.rails.output.streaming,
-                    messages=messages,
-                    prompt=prompt,
-                )
-            else:
-                return generator
-
-        self._explain_info = self._ensure_explain_info()
-
-        streaming_handler = StreamingHandler(include_metadata=include_metadata)
-
-        # Create a properly managed task with exception handling
-        async def _generation_task():
-            try:
-                await self.generate_async(
-                    prompt=prompt,
-                    messages=messages,
-                    streaming_handler=streaming_handler,
-                    options=options,
-                    state=state,
-                )
-            except Exception as e:
-                # If an exception occurs during generation, push it to the streaming handler as a json string
-                # This ensures the streaming pipeline is properly terminated
-                log.error(f"Error in generation task: {e}", exc_info=True)
-                error_message = str(e)
-                error_dict = extract_error_json(error_message)
-                error_payload = json.dumps(error_dict)
-                await streaming_handler.push_chunk(error_payload)
-                await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
-
-        task = asyncio.create_task(_generation_task())
-
-        # Store task reference to prevent garbage collection and ensure proper cleanup
-        if not hasattr(self, "_active_tasks"):
-            self._active_tasks = set()
-        self._active_tasks.add(task)
-
-        # Clean up task when it's done
-        def task_done_callback(task):
-            self._active_tasks.discard(task)
-
-        task.add_done_callback(task_done_callback)
-
-        # when we have output rails we wrap the streaming handler
-        # if len(self.config.rails.output.flows) > 0:
-        #
-        if self.config.rails.output.streaming and self.config.rails.output.streaming.enabled:
-            base_iterator = self._run_output_rails_in_streaming(
-                streaming_handler=streaming_handler,
-                output_rails_streaming_config=self.config.rails.output.streaming,
-                messages=messages,
-                prompt=prompt,
-            )
-        else:
-            base_iterator = streaming_handler
-
-        async def wrapped_iterator():
-            try:
-                async for chunk in base_iterator:
-                    if chunk is not None:
-                        yield chunk
-            finally:
-                await task
-
-        return wrapped_iterator()
+        validate_public_state(self.config, state)
+        return generation_token_stream(
+            self,
+            prompt=prompt,
+            messages=messages,
+            options=options,
+            state=state,
+            include_metadata=include_metadata,
+            generator=generator,
+            include_generation_metadata=include_generation_metadata,
+        )
 
     def generate(
         self,
@@ -886,246 +793,15 @@ class LLMRails(BaseGuardrails):
         2. Runs sequential (parallel for colang 2.0 in future) flows for each chunk.
         3. Yields the chunk if not blocked, or STOP if blocked.
         """
-
-        def _get_last_context_message(
-            messages: Optional[List[dict]] = None,
-        ) -> dict:
-            if messages is None:
-                return {}
-
-            for message in reversed(messages):
-                if message.get("role") == "context":
-                    return message
-            return {}
-
-        def _get_latest_user_message(
-            messages: Optional[List[dict]] = None,
-        ) -> dict:
-            if messages is None:
-                return {}
-            for message in reversed(messages):
-                if message.get("role") == "user":
-                    return message
-            return {}
-
-        def _prepare_context_for_parallel_rails(
-            chunk_str: str,
-            prompt: Optional[str] = None,
-            messages: Optional[List[dict]] = None,
-        ) -> dict:
-            """Prepare context for parallel rails execution."""
-            context_message = _get_last_context_message(messages)
-            user_message = prompt or _get_latest_user_message(messages)
-
-            context = {
-                "user_message": user_message,
-                "bot_message": chunk_str,
-            }
-
-            if context_message:
-                context.update(context_message["content"])
-
-            return context
-
-        def _create_events_for_chunk(chunk_str: str, context: dict) -> List[dict]:
-            """Create events for running output rails on a chunk."""
-            return [
-                {"type": "ContextUpdate", "data": context},
-                {"type": "BotMessage", "text": chunk_str},
-            ]
-
-        def _prepare_params(
-            flow_id: str,
-            action_name: str,
-            bot_response_chunk: str,
-            prompt: Optional[str] = None,
-            messages: Optional[List[dict]] = None,
-            action_params: Dict[str, Any] = {},
+        async for chunk in run_output_rails_in_streaming(
+            self,
+            streaming_handler=streaming_handler,
+            output_rails_streaming_config=output_rails_streaming_config,
+            prompt=prompt,
+            messages=messages,
+            stream_first=stream_first,
         ):
-            context_message = _get_last_context_message(messages)
-            user_message = prompt or _get_latest_user_message(messages)
-
-            context = {
-                "user_message": user_message,
-                "bot_message": bot_response_chunk,
-            }
-
-            if context_message:
-                context.update(context_message["content"])
-
-            model_name = flow_id.split("$")[-1].split("=")[-1].strip('"')
-
-            # we pass action params that are defined in the flow
-            # caveate, e.g. prmpt_security uses bot_response=$bot_message
-            # to resolve replace placeholders in action_params
-            for key, value in action_params.items():
-                if value == "$bot_message":
-                    action_params[key] = bot_response_chunk
-                elif value == "$user_message":
-                    action_params[key] = user_message
-
-            return {
-                # TODO:: are there other context variables that need to be passed?
-                # passing events to compute context was not successful
-                # context var failed due to different context
-                "context": context,
-                "llm_task_manager": self.runtime.llm_task_manager,
-                "config": self.config,
-                "model_name": model_name,
-                "llms": self.runtime.registered_action_params.get("llms", {}),
-                "llm": self.runtime.registered_action_params.get(f"{action_name}_llm", self.llm),
-                **action_params,
-            }
-
-        buffer_strategy = get_buffer_strategy(output_rails_streaming_config)
-        output_rails_flows_id = self.config.rails.output.flows
-        stream_first = stream_first or output_rails_streaming_config.stream_first
-        get_action_details = partial(get_action_details_from_flow_id, flows=self.config.flows)
-
-        parallel_mode = getattr(self.config.rails.output, "parallel", False)
-
-        async for chunk_batch in buffer_strategy(streaming_handler):
-            user_output_chunks = chunk_batch.user_output_chunks
-            # format processing_context for output rails processing (needs full context)
-            bot_response_chunk = buffer_strategy.format_chunks(chunk_batch.processing_context)
-
-            # check if user_output_chunks is a list of individual chunks
-            # or if it's a JSON string, by convention this means an error occurred and the error dict is stored as a JSON
-            if not isinstance(user_output_chunks, list):
-                try:
-                    json.loads(user_output_chunks)
-                    yield user_output_chunks
-                    return
-                except (json.JSONDecodeError, TypeError):
-                    # if it's not JSON, treat it as empty list
-                    user_output_chunks = []
-
-            if stream_first:
-                # yield the individual chunks directly from the buffer strategy
-                for chunk in user_output_chunks:
-                    yield chunk
-
-            if parallel_mode:
-                try:
-                    context = _prepare_context_for_parallel_rails(bot_response_chunk, prompt, messages)
-                    events = _create_events_for_chunk(bot_response_chunk, context)
-
-                    flows_with_params = {}
-                    for flow_id in output_rails_flows_id:
-                        action_name, action_params = get_action_details(flow_id)
-                        params = _prepare_params(
-                            flow_id=flow_id,
-                            action_name=action_name,
-                            bot_response_chunk=bot_response_chunk,
-                            prompt=prompt,
-                            messages=messages,
-                            action_params=action_params,
-                        )
-                        flows_with_params[flow_id] = {
-                            "action_name": action_name,
-                            "params": params,
-                        }
-
-                    result_tuple = await self.runtime.action_dispatcher.execute_action(
-                        "run_output_rails_in_parallel_streaming",
-                        {
-                            "flows_with_params": flows_with_params,
-                            "events": events,
-                        },
-                    )
-
-                    # ActionDispatcher.execute_action always returns (result, status)
-                    result, status = result_tuple
-
-                    if status != "success":
-                        log.error(f"Parallel rails execution failed with status: {status}")
-                        # continue processing the chunk even if rails fail
-                        pass
-                    else:
-                        # if there are any stop events, content was blocked or internal error occurred
-                        result_events = getattr(result, "events", None)
-                        if result_events:
-                            # extract the flow info from the first stop event
-                            stop_event = result_events[0]
-                            blocked_flow = stop_event.get("flow_id", "output rails")
-                            error_type = stop_event.get("error_type")
-
-                            if error_type == "internal_error":
-                                error_message = stop_event.get("error_message", "Unknown error")
-                                reason = f"Internal error in {blocked_flow} rail: {error_message}"
-                                error_code = "rail_execution_failure"
-                                error_type = "internal_error"
-                            else:
-                                reason = f"Blocked by {blocked_flow} rails."
-                                error_code = "content_blocked"
-                                error_type = "guardrails_violation"
-
-                            error_data = {
-                                "error": {
-                                    "message": reason,
-                                    "type": error_type,
-                                    "param": blocked_flow,
-                                    "code": error_code,
-                                }
-                            }
-                            yield json.dumps(error_data)
-                            return
-
-                except Exception as e:
-                    log.error(f"Error in parallel rail execution: {e}")
-                    # don't block the stream for rail execution errors
-                    # continue processing the chunk
-                    pass
-
-                # update explain info for parallel mode
-                self._explain_info = self._ensure_explain_info()
-
-            else:
-                for flow_id in output_rails_flows_id:
-                    action_name, action_params = get_action_details(flow_id)
-
-                    params = _prepare_params(
-                        flow_id=flow_id,
-                        action_name=action_name,
-                        bot_response_chunk=bot_response_chunk,
-                        prompt=prompt,
-                        messages=messages,
-                        action_params=action_params,
-                    )
-
-                    result = await self.runtime.action_dispatcher.execute_action(action_name, params)
-                    self._explain_info = self._ensure_explain_info()
-
-                    action_func = self.runtime.action_dispatcher.get_action(action_name)
-
-                    # Use the mapping to decide if the result indicates blocked content.
-                    if is_output_blocked(result, action_func):
-                        reason = f"Blocked by {flow_id} rails."
-
-                        # return the error as a plain JSON string (not in SSE format)
-                        # NOTE: When integrating with the OpenAI Python client, the server code should:
-                        # 1. detect this JSON error object in the stream
-                        # 2. terminate the stream
-                        # 3. format the error following OpenAI's SSE format
-                        # the OpenAI client will then properly raise an APIError with this error message
-
-                        error_data = {
-                            "error": {
-                                "message": reason,
-                                "type": "guardrails_violation",
-                                "param": flow_id,
-                                "code": "content_blocked",
-                            }
-                        }
-
-                        # return as plain JSON: the server should detect this JSON and convert it to an HTTP error
-                        yield json.dumps(error_data)
-                        return
-
-            if not stream_first:
-                # yield the individual chunks directly from the buffer strategy
-                for chunk in user_output_chunks:
-                    yield chunk
+            yield chunk
 
 
 def _determine_rails_from_messages(messages: List[dict]) -> Optional[dict]:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -21,7 +21,6 @@ from typing import (
     Any,
     AsyncIterator,
     Callable,
-    Dict,
     List,
     Literal,
     Optional,
@@ -43,11 +42,8 @@ from nemoguardrails.llm.models.initializer import init_llm_model
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.logging.verbose import set_verbose
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
-from nemoguardrails.rails.llm.config import (
-    OutputRailsStreamingConfig,
-    RailsConfig,
-)
-from nemoguardrails.rails.llm.conversation.conversation_events import events_for_messages
+from nemoguardrails.rails.llm.checks import rails_check
+from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig, RailsConfig
 from nemoguardrails.rails.llm.generation.generation_context import (
     ensure_explain_info,
     explain_info_for_current_context,
@@ -58,13 +54,7 @@ from nemoguardrails.rails.llm.generation.generation_request import (
     validate_public_state,
 )
 from nemoguardrails.rails.llm.generation.generation_workflow import generate_standard_async
-from nemoguardrails.rails.llm.options import (
-    GenerationOptions,
-    GenerationResponse,
-    RailsResult,
-    RailStatus,
-    RailType,
-)
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse, RailsResult, RailType
 from nemoguardrails.rails.llm.runtime.colang_runtime import runtime_for_colang_version
 from nemoguardrails.rails.llm.runtime.colang_turns import (
     generate_colang_events,
@@ -229,17 +219,10 @@ class LLMRails(BaseGuardrails):
 
     @property
     def passthrough_fn(self):
-        """The optional passthrough function that bypasses LLM generation.
-
-        When set, the rails pipeline calls this function instead of the main LLM
-        for generating responses. LLMGenerationActions is private, expose only
-        `passthrough_fn` as a public API
-        """
         return self._llm_generation_actions._passthrough_fn
 
     @passthrough_fn.setter
     def passthrough_fn(self, fn):
-        """LLMGenerationActions is private, set passthrough_fn directly"""
         self._llm_generation_actions._passthrough_fn = fn
 
     @property
@@ -366,12 +349,6 @@ class LLMRails(BaseGuardrails):
         load_llm_action_models(self, init_llm=init_llm_model)
         initialize_llm_action_caches(self)
 
-    def _get_embeddings_search_provider_instance(self, esp_config=None):
-        return self.embedding_search.get_provider_instance(esp_config)
-
-    def _get_events_for_messages(self, messages: List[dict], state: Any):
-        return events_for_messages(self, messages, state)
-
     @staticmethod
     def _ensure_explain_info() -> ExplainInfo:
         """Ensure that the ExplainInfo variable is present in the current context
@@ -381,9 +358,8 @@ class LLMRails(BaseGuardrails):
         """
         return ensure_explain_info()
 
-    def _validate_public_state(self, state: Optional[Union[dict, State]]) -> None:
-        """Validate public dict state passed through generate/generate_async."""
-        validate_public_state(self.config, state)
+    def _get_embeddings_search_provider_instance(self, esp_config=None):
+        return self.embedding_search.get_provider_instance(esp_config)
 
     async def generate_async(
         self,
@@ -654,38 +630,7 @@ class LLMRails(BaseGuardrails):
 
                 result = await rails.check_async(messages, rail_types=[RailType.INPUT])
         """
-        if rail_types is not None:
-            options: Optional[dict] = {"rails": [r.value for r in rail_types]}
-        else:
-            options = _determine_rails_from_messages(messages)
-
-        if options is None:
-            last_content = messages[-1].get("content", "") if messages else ""
-            return RailsResult(status=RailStatus.PASSED, content=last_content)
-
-        rails_to_run = options["rails"]
-        if "output" in rails_to_run:
-            original_content = _get_last_content_by_role(messages, "assistant")
-        else:
-            original_content = _get_last_content_by_role(messages, "user")
-
-        messages = _normalize_messages_for_rails(messages, rails_to_run)
-        options["log"] = {"activated_rails": True}
-
-        response = await self.generate_async(messages=messages, options=options)
-
-        if not isinstance(response, GenerationResponse):
-            raise RuntimeError(f"Expected GenerationResponse, got {type(response).__name__}")
-
-        blocking_rail = _get_blocking_rail(response)
-        result_content = _get_last_response_content(response)
-
-        if blocking_rail:
-            return RailsResult(status=RailStatus.BLOCKED, content=result_content, rail=blocking_rail)
-
-        if result_content != original_content:
-            return RailsResult(status=RailStatus.MODIFIED, content=result_content)
-        return RailsResult(status=RailStatus.PASSED, content=result_content)
+        return await rails_check.check_messages(self, messages, rail_types=rail_types)
 
     def check(
         self,
@@ -712,22 +657,38 @@ class LLMRails(BaseGuardrails):
         return loop.run_until_complete(self.check_async(messages, rail_types=rail_types))
 
     def register_action(self, action: Callable, name: Optional[str] = None) -> Self:
-        """Register a custom action for the rails configuration."""
+        """Register a custom action for the rails configuration.
+
+        This mutates the runtime action registry and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.register_action(action, name)
         return self
 
     def register_action_param(self, name: str, value: Any) -> Self:
-        """Registers a custom action parameter."""
+        """Register a custom action parameter.
+
+        This mutates runtime action dependencies and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.register_action_param(name, value)
         return self
 
     def register_filter(self, filter_fn: Callable, name: Optional[str] = None) -> Self:
-        """Register a custom filter for the rails configuration."""
+        """Register a custom filter for the rails configuration.
+
+        This mutates the runtime task manager and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.llm_task_manager.register_filter(filter_fn, name)
         return self
 
     def register_output_parser(self, output_parser: Callable, name: str) -> Self:
-        """Register a custom output parser for the rails configuration."""
+        """Register a custom output parser for the rails configuration.
+
+        This mutates the runtime task manager and is intended to be called
+        during application startup, before concurrent generation requests begin.
+        """
         self.runtime.llm_task_manager.register_output_parser(output_parser, name)
         return self
 
@@ -736,6 +697,9 @@ class LLMRails(BaseGuardrails):
 
         :name: The name of the variable or function that will be used.
         :value_or_fn: The value or function that will be used to generate the value.
+
+        This mutates the runtime task manager and is intended to be called
+        during application startup, before concurrent generation requests begin.
         """
         self.runtime.llm_task_manager.register_prompt_context(name, value_or_fn)
         return self
@@ -746,6 +710,9 @@ class LLMRails(BaseGuardrails):
         Args:
             name: The name of the embedding search provider that will be used.
             cls: The class that will be used to generate and search embedding
+
+        This updates the instance provider registry. Register providers during
+        startup so knowledge-base and generation-action setup can see them.
         """
 
         self.embedding_search.register_provider(name, cls)
@@ -761,6 +728,9 @@ class LLMRails(BaseGuardrails):
         Raises:
             ValueError: If the engine name is not provided and the model does not have an engine name.
             ValueError: If the model does not have 'encode' or 'encode_async' methods.
+
+        This updates the process-global embedding provider registry and is
+        intended to be called during application startup.
         """
         register_embedding_provider(engine_name=name, model=cls)
         return self
@@ -802,58 +772,3 @@ class LLMRails(BaseGuardrails):
             stream_first=stream_first,
         ):
             yield chunk
-
-
-def _determine_rails_from_messages(messages: List[dict]) -> Optional[dict]:
-    roles = {msg.get("role") for msg in reversed(messages)}
-    has_user = "user" in roles
-    has_assistant = "assistant" in roles
-
-    if not has_user and not has_assistant:
-        log.warning(
-            "check() called with no user or assistant messages. "
-            "Only system, context, or tool messages found. "
-            "Returning passing result without running rails."
-        )
-        return None
-
-    if has_user and has_assistant:
-        return {"rails": ["input", "output"]}
-    if has_user:
-        return {"rails": ["input"]}
-    return {"rails": ["output"]}
-
-
-def _normalize_messages_for_rails(
-    messages: List[dict],
-    rails: List[str],
-) -> List[dict]:
-    if rails == ["output"]:
-        has_user = any(msg.get("role") == "user" for msg in messages)
-        if not has_user:
-            return [{"role": "user", "content": ""}] + messages
-
-    return messages
-
-
-def _get_last_content_by_role(messages: List[dict], role: str) -> str:
-    for msg in reversed(messages):
-        if msg.get("role") == role:
-            return msg.get("content", "")
-    return ""
-
-
-def _get_blocking_rail(response: "GenerationResponse") -> Optional[str]:
-    if response.log and response.log.activated_rails:
-        for rail in response.log.activated_rails:
-            if rail.stop:
-                return rail.name
-    return None
-
-
-def _get_last_response_content(response: "GenerationResponse") -> str:
-    if isinstance(response.response, list) and response.response:
-        return response.response[-1].get("content", "")
-    if isinstance(response.response, str):
-        return response.response
-    return ""

--- a/nemoguardrails/rails/llm/startup/colang_flows.py
+++ b/nemoguardrails/rails/llm/startup/colang_flows.py
@@ -67,6 +67,21 @@ def _iter_colang_resources(resource: Traversable) -> Iterator[Traversable]:
             yield from _iter_colang_resources(child)
 
 
+def _flow_config_key(flow_config: dict) -> str | None:
+    return flow_config.get("id") or flow_config.get("name")
+
+
+def _extend_missing_flow_configs(config: RailsConfig, flow_configs: list[dict]) -> None:
+    existing_flow_keys = {_flow_config_key(flow_config) for flow_config in config.flows}
+    for flow_config in flow_configs:
+        flow_key = _flow_config_key(flow_config)
+        if flow_key is not None and flow_key in existing_flow_keys:
+            continue
+
+        config.flows.append(flow_config)
+        existing_flow_keys.add(flow_key)
+
+
 def load_default_colang_1_flows(config: RailsConfig) -> None:
     """Load the built-in Colang 1.0 LLM flows into the rails config."""
     if config.colang_version != "1.0":
@@ -79,7 +94,7 @@ def load_default_colang_1_flows(config: RailsConfig) -> None:
     for flow_config in default_flows:
         flow_config["is_system_flow"] = True
 
-    config.flows.extend(default_flows)
+    _extend_missing_flow_configs(config, default_flows)
 
 
 def load_guardrails_library_flows_and_bot_messages(config: RailsConfig) -> None:
@@ -101,7 +116,7 @@ def load_guardrails_library_flows_and_bot_messages(config: RailsConfig) -> None:
         for flow_config in content["flows"]:
             flow_config["is_system_flow"] = True
 
-        config.flows.extend(content["flows"])
+        _extend_missing_flow_configs(config, content["flows"])
 
         for message_id, utterances in content.get("bot_messages", {}).items():
             if message_id not in config.bot_messages:

--- a/nemoguardrails/rails/llm/streaming/__init__.py
+++ b/nemoguardrails/rails/llm/streaming/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.rails.llm.streaming.generation_stream import (
+    GenerationStreamRails,
+    generation_token_stream,
+)
+from nemoguardrails.rails.llm.streaming.streaming_output_rails import (
+    StreamingOutputActionDispatcher,
+    StreamingOutputRails,
+    StreamingOutputRuntime,
+    run_output_rails_in_streaming,
+)
+
+__all__ = [
+    "GenerationStreamRails",
+    "StreamingOutputActionDispatcher",
+    "StreamingOutputRails",
+    "StreamingOutputRuntime",
+    "generation_token_stream",
+    "run_output_rails_in_streaming",
+]

--- a/nemoguardrails/rails/llm/streaming/generation_stream.py
+++ b/nemoguardrails/rails/llm/streaming/generation_stream.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation token stream lifecycle helpers."""
+
+import asyncio
+import json
+import logging
+import warnings
+from typing import Any, AsyncIterator, Optional, Protocol, Union, cast
+
+from nemoguardrails.exceptions import StreamingNotSupportedError
+from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.rails.llm.streaming.streaming_output_rails import (
+    StreamingOutputRails,
+    run_output_rails_in_streaming,
+)
+from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
+from nemoguardrails.utils import extract_error_json
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "GenerationStreamRails",
+    "generation_token_stream",
+    "validate_streaming_with_output_rails",
+]
+
+
+class GenerationStreamRails(StreamingOutputRails, Protocol):
+    async def generate_async(
+        self,
+        *,
+        prompt: Optional[str] = None,
+        messages: Optional[list[dict]] = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        state: Optional[Any] = None,
+        streaming_handler: Optional[StreamingHandler] = None,
+    ) -> object: ...
+
+
+def validate_streaming_with_output_rails(config: Any) -> None:
+    if len(config.rails.output.flows) > 0 and (
+        not config.rails.output.streaming or not config.rails.output.streaming.enabled
+    ):
+        raise StreamingNotSupportedError(
+            "stream_async() cannot be used when output rails are configured but "
+            "rails.output.streaming.enabled is False. Either set "
+            "rails.output.streaming.enabled to True in your configuration, or use "
+            "generate_async() instead of stream_async()."
+        )
+
+
+def generation_token_stream(
+    rails: GenerationStreamRails,
+    *,
+    prompt: Optional[str] = None,
+    messages: Optional[list[dict]] = None,
+    options: Optional[Union[dict, GenerationOptions]] = None,
+    state: Optional[Any] = None,
+    include_metadata: Optional[bool] = False,
+    generator: Optional[AsyncIterator[str]] = None,
+    include_generation_metadata: Optional[bool] = None,
+) -> AsyncIterator[Union[str, dict]]:
+    """Return the token stream for a generation request."""
+    if include_generation_metadata is not None:
+        warnings.warn(
+            "include_generation_metadata is deprecated, use include_metadata instead. "
+            "It will be removed in version 0.22.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        include_metadata = include_generation_metadata
+
+    validate_streaming_with_output_rails(rails.config)
+
+    if generator:
+        if rails.config.rails.output.streaming and rails.config.rails.output.streaming.enabled:
+            return run_output_rails_in_streaming(
+                rails,
+                streaming_handler=generator,
+                output_rails_streaming_config=rails.config.rails.output.streaming,
+                messages=messages,
+                prompt=prompt,
+            )
+        return generator
+
+    rails._explain_info = rails._ensure_explain_info()
+
+    streaming_handler = StreamingHandler(include_metadata=include_metadata)
+
+    async def _generation_task():
+        try:
+            await rails.generate_async(
+                prompt=prompt,
+                messages=messages,
+                streaming_handler=streaming_handler,
+                options=options,
+                state=state,
+            )
+        except Exception as e:
+            # If an exception occurs during generation, push it to the streaming
+            # handler as a json string. This ensures the streaming pipeline is
+            # properly terminated.
+            log.error(f"Error in generation task: {e}", exc_info=True)
+            error_message = str(e)
+            error_dict = extract_error_json(error_message)
+            error_payload = json.dumps(error_dict)
+            await streaming_handler.push_chunk(error_payload)
+            await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
+
+    task = asyncio.create_task(_generation_task())
+    _track_generation_task(rails, task)
+
+    output_rail_streaming_enabled = bool(
+        rails.config.rails.output.streaming and rails.config.rails.output.streaming.enabled
+    )
+    if output_rail_streaming_enabled:
+        base_iterator = run_output_rails_in_streaming(
+            rails,
+            streaming_handler=streaming_handler,
+            output_rails_streaming_config=rails.config.rails.output.streaming,
+            messages=messages,
+            prompt=prompt,
+        )
+    else:
+        base_iterator = streaming_handler
+
+    async def wrapped_iterator():
+        try:
+            async for chunk in base_iterator:
+                if chunk is not None:
+                    yield chunk
+        finally:
+            await task
+
+    return wrapped_iterator()
+
+
+def _track_generation_task(rails: GenerationStreamRails, task: asyncio.Task) -> None:
+    """Track background stream tasks so they are not garbage collected."""
+    task_holder = cast(Any, rails)
+    if not hasattr(task_holder, "_active_tasks"):
+        task_holder._active_tasks = set()
+    task_holder._active_tasks.add(task)
+
+    def task_done_callback(task):
+        task_holder._active_tasks.discard(task)
+
+    task.add_done_callback(task_done_callback)

--- a/nemoguardrails/rails/llm/streaming/generation_stream.py
+++ b/nemoguardrails/rails/llm/streaming/generation_stream.py
@@ -139,14 +139,34 @@ def generation_token_stream(
         base_iterator = streaming_handler
 
     async def wrapped_iterator():
+        stream_completed = False
+        terminal_output_rail_error = False
         try:
             async for chunk in base_iterator:
                 if chunk is not None:
+                    if output_rail_streaming_enabled and _is_stream_error_chunk(chunk):
+                        terminal_output_rail_error = True
                     yield chunk
+            stream_completed = True
         finally:
-            await task
+            await _finish_generation_task(
+                task,
+                stream_completed=stream_completed and not terminal_output_rail_error,
+            )
 
     return wrapped_iterator()
+
+
+def _is_stream_error_chunk(chunk: Union[str, dict]) -> bool:
+    if not isinstance(chunk, str):
+        return False
+
+    try:
+        chunk_data = json.loads(chunk)
+    except json.JSONDecodeError:
+        return False
+
+    return isinstance(chunk_data, dict) and "error" in chunk_data
 
 
 def _track_generation_task(rails: GenerationStreamRails, task: asyncio.Task) -> None:
@@ -160,3 +180,21 @@ def _track_generation_task(rails: GenerationStreamRails, task: asyncio.Task) -> 
         task_holder._active_tasks.discard(task)
 
     task.add_done_callback(task_done_callback)
+
+
+async def _finish_generation_task(
+    task: asyncio.Task,
+    *,
+    stream_completed: bool,
+) -> None:
+    """Finalize a background generation task for a stream consumer."""
+    cancelled_by_stream_close = False
+    if not stream_completed and not task.done():
+        task.cancel()
+        cancelled_by_stream_close = True
+
+    try:
+        await task
+    except asyncio.CancelledError:
+        if not cancelled_by_stream_close:
+            raise

--- a/nemoguardrails/rails/llm/streaming/streaming_output_rails.py
+++ b/nemoguardrails/rails/llm/streaming/streaming_output_rails.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Buffered output rail streaming helpers."""
+
+import json
+import logging
+from functools import partial
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Protocol
+
+from nemoguardrails.actions.output_mapping import is_output_blocked
+from nemoguardrails.rails.llm.buffer import get_buffer_strategy
+from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig
+from nemoguardrails.rails.llm.utils import get_action_details_from_flow_id
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "StreamingOutputActionDispatcher",
+    "StreamingOutputRails",
+    "StreamingOutputRuntime",
+    "run_output_rails_in_streaming",
+]
+
+
+class StreamingOutputActionDispatcher(Protocol):
+    async def execute_action(self, action_name: str, params: Dict[str, Any]) -> Any: ...
+
+    def get_action(self, name: str, /) -> Any: ...
+
+
+class StreamingOutputRuntime(Protocol):
+    @property
+    def action_dispatcher(self) -> StreamingOutputActionDispatcher: ...
+
+    @property
+    def llm_task_manager(self) -> Any: ...
+
+    @property
+    def registered_action_params(self) -> Dict[str, Any]: ...
+
+
+class StreamingOutputRails(Protocol):
+    _explain_info: Any
+
+    @property
+    def config(self) -> Any: ...
+
+    @property
+    def runtime(self) -> StreamingOutputRuntime: ...
+
+    @property
+    def llm(self) -> Any: ...
+
+    def _ensure_explain_info(self) -> Any: ...
+
+
+async def run_output_rails_in_streaming(
+    rails: StreamingOutputRails,
+    streaming_handler: AsyncIterator[str],
+    output_rails_streaming_config: OutputRailsStreamingConfig,
+    prompt: Optional[str] = None,
+    messages: Optional[List[dict]] = None,
+    stream_first: Optional[bool] = None,
+) -> AsyncIterator[str]:
+    """
+    1. Buffers tokens from 'streaming_handler' via BufferStrategy.
+    2. Runs sequential (parallel for colang 2.0 in future) flows for each chunk.
+    3. Yields the chunk if not blocked, or STOP if blocked.
+    """
+    buffer_strategy = get_buffer_strategy(output_rails_streaming_config)
+    output_rails_flows_id = rails.config.rails.output.flows
+    stream_first = stream_first or output_rails_streaming_config.stream_first
+    get_action_details = partial(get_action_details_from_flow_id, flows=rails.config.flows)
+
+    parallel_mode = getattr(rails.config.rails.output, "parallel", False)
+
+    async for chunk_batch in buffer_strategy(streaming_handler):
+        user_output_chunks = chunk_batch.user_output_chunks
+        # format processing_context for output rails processing (needs full context)
+        bot_response_chunk = buffer_strategy.format_chunks(chunk_batch.processing_context)
+
+        # check if user_output_chunks is a list of individual chunks
+        # or if it's a JSON string, by convention this means an error occurred and the error dict is stored as a JSON
+        if not isinstance(user_output_chunks, list):
+            try:
+                json.loads(user_output_chunks)
+                yield user_output_chunks
+                return
+            except (json.JSONDecodeError, TypeError):
+                # if it's not JSON, treat it as empty list
+                user_output_chunks = []
+
+        if stream_first:
+            # yield the individual chunks directly from the buffer strategy
+            for chunk in user_output_chunks:
+                yield chunk
+
+        if parallel_mode:
+            async for chunk in _run_parallel_output_rails(
+                rails=rails,
+                output_rails_flows_id=output_rails_flows_id,
+                get_action_details=get_action_details,
+                bot_response_chunk=bot_response_chunk,
+                prompt=prompt,
+                messages=messages,
+            ):
+                yield chunk
+                return
+        else:
+            async for chunk in _run_sequential_output_rails(
+                rails=rails,
+                output_rails_flows_id=output_rails_flows_id,
+                get_action_details=get_action_details,
+                bot_response_chunk=bot_response_chunk,
+                prompt=prompt,
+                messages=messages,
+            ):
+                yield chunk
+                return
+
+        if not stream_first:
+            # yield the individual chunks directly from the buffer strategy
+            for chunk in user_output_chunks:
+                yield chunk
+
+
+async def _run_parallel_output_rails(
+    *,
+    rails: StreamingOutputRails,
+    output_rails_flows_id: List[str],
+    get_action_details: Callable[[str], tuple[str, Dict[str, Any]]],
+    bot_response_chunk: str,
+    prompt: Optional[str],
+    messages: Optional[List[dict]],
+) -> AsyncIterator[str]:
+    try:
+        context = _prepare_context_for_parallel_rails(bot_response_chunk, prompt, messages)
+        events = _create_events_for_chunk(bot_response_chunk, context)
+
+        flows_with_params = {}
+        for flow_id in output_rails_flows_id:
+            action_name, action_params = get_action_details(flow_id)
+            params = _prepare_params(
+                rails=rails,
+                flow_id=flow_id,
+                action_name=action_name,
+                bot_response_chunk=bot_response_chunk,
+                prompt=prompt,
+                messages=messages,
+                action_params=action_params,
+            )
+            flows_with_params[flow_id] = {
+                "action_name": action_name,
+                "params": params,
+            }
+
+        result_tuple = await rails.runtime.action_dispatcher.execute_action(
+            "run_output_rails_in_parallel_streaming",
+            {
+                "flows_with_params": flows_with_params,
+                "events": events,
+            },
+        )
+
+        # ActionDispatcher.execute_action always returns (result, status)
+        result, status = result_tuple
+
+        if status != "success":
+            log.error(f"Parallel rails execution failed with status: {status}")
+        else:
+            # if there are any stop events, content was blocked or internal error occurred
+            result_events = getattr(result, "events", None)
+            if result_events:
+                yield _parallel_stop_error(result_events[0])
+                return
+
+    except Exception as e:
+        log.error(f"Error in parallel rail execution: {e}")
+
+    # update explain info for parallel mode
+    rails._explain_info = rails._ensure_explain_info()
+
+
+async def _run_sequential_output_rails(
+    *,
+    rails: StreamingOutputRails,
+    output_rails_flows_id: List[str],
+    get_action_details: Callable[[str], tuple[str, Dict[str, Any]]],
+    bot_response_chunk: str,
+    prompt: Optional[str],
+    messages: Optional[List[dict]],
+) -> AsyncIterator[str]:
+    for flow_id in output_rails_flows_id:
+        action_name, action_params = get_action_details(flow_id)
+
+        params = _prepare_params(
+            rails=rails,
+            flow_id=flow_id,
+            action_name=action_name,
+            bot_response_chunk=bot_response_chunk,
+            prompt=prompt,
+            messages=messages,
+            action_params=action_params,
+        )
+
+        action_result = await rails.runtime.action_dispatcher.execute_action(action_name, params)
+        rails._explain_info = rails._ensure_explain_info()
+
+        # Use the mapping to decide if the result indicates blocked content.
+        action_func = rails.runtime.action_dispatcher.get_action(action_name)
+        if is_output_blocked(action_result, action_func):
+            yield _blocked_output_error(flow_id)
+            return
+
+
+def _get_last_context_message(
+    messages: Optional[List[dict]] = None,
+) -> dict:
+    if messages is None:
+        return {}
+
+    for message in reversed(messages):
+        if message.get("role") == "context":
+            return message
+    return {}
+
+
+def _get_latest_user_message(
+    messages: Optional[List[dict]] = None,
+) -> dict:
+    if messages is None:
+        return {}
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            return message
+    return {}
+
+
+def _prepare_context_for_parallel_rails(
+    chunk_str: str,
+    prompt: Optional[str] = None,
+    messages: Optional[List[dict]] = None,
+) -> dict:
+    """Prepare context for parallel rails execution."""
+    context_message = _get_last_context_message(messages)
+    user_message = prompt or _get_latest_user_message(messages)
+
+    context = {
+        "user_message": user_message,
+        "bot_message": chunk_str,
+    }
+
+    if context_message:
+        context.update(context_message["content"])
+
+    return context
+
+
+def _create_events_for_chunk(chunk_str: str, context: dict) -> List[dict]:
+    """Create events for running output rails on a chunk."""
+    return [
+        {"type": "ContextUpdate", "data": context},
+        {"type": "BotMessage", "text": chunk_str},
+    ]
+
+
+def _prepare_params(
+    *,
+    rails: StreamingOutputRails,
+    flow_id: str,
+    action_name: str,
+    bot_response_chunk: str,
+    prompt: Optional[str] = None,
+    messages: Optional[List[dict]] = None,
+    action_params: Dict[str, Any],
+):
+    context_message = _get_last_context_message(messages)
+    user_message = prompt or _get_latest_user_message(messages)
+
+    context = {
+        "user_message": user_message,
+        "bot_message": bot_response_chunk,
+    }
+
+    if context_message:
+        context.update(context_message["content"])
+
+    model_name = flow_id.split("$")[-1].split("=")[-1].strip('"')
+
+    # we pass action params that are defined in the flow
+    # caveate, e.g. prmpt_security uses bot_response=$bot_message
+    # to resolve replace placeholders in action_params
+    action_params = dict(action_params)
+    for key, value in action_params.items():
+        if value == "$bot_message":
+            action_params[key] = bot_response_chunk
+        elif value == "$user_message":
+            action_params[key] = user_message
+
+    return {
+        # TODO:: are there other context variables that need to be passed?
+        # passing events to compute context was not successful
+        # context var failed due to different context
+        "context": context,
+        "llm_task_manager": rails.runtime.llm_task_manager,
+        "config": rails.config,
+        "model_name": model_name,
+        "llms": rails.runtime.registered_action_params.get("llms", {}),
+        "llm": rails.runtime.registered_action_params.get(f"{action_name}_llm", rails.llm),
+        **action_params,
+    }
+
+
+def _blocked_output_error(flow_id: str) -> str:
+    reason = f"Blocked by {flow_id} rails."
+
+    # return the error as a plain JSON string (not in SSE format)
+    # NOTE: When integrating with the OpenAI Python client, the server code should:
+    # 1. detect this JSON error object in the stream
+    # 2. terminate the stream
+    # 3. format the error following OpenAI's SSE format
+    # the OpenAI client will then properly raise an APIError with this error message
+    error_data = {
+        "error": {
+            "message": reason,
+            "type": "guardrails_violation",
+            "param": flow_id,
+            "code": "content_blocked",
+        }
+    }
+
+    # return as plain JSON: the server should detect this JSON and convert it to an HTTP error
+    return json.dumps(error_data)
+
+
+def _internal_rail_error(flow_id: str, error_message: str) -> str:
+    error_data = {
+        "error": {
+            "message": f"Internal error in {flow_id} rail: {error_message}",
+            "type": "internal_error",
+            "param": flow_id,
+            "code": "rail_execution_failure",
+        }
+    }
+    return json.dumps(error_data)
+
+
+def _parallel_stop_error(stop_event: dict) -> str:
+    blocked_flow = stop_event.get("flow_id", "output rails")
+    error_type = stop_event.get("error_type")
+
+    if error_type == "internal_error":
+        error_message = stop_event.get("error_message", "Unknown error")
+        return _internal_rail_error(blocked_flow, error_message)
+    else:
+        reason = f"Blocked by {blocked_flow} rails."
+        error_code = "content_blocked"
+        error_type = "guardrails_violation"
+
+    error_data = {
+        "error": {
+            "message": reason,
+            "type": error_type,
+            "param": blocked_flow,
+            "code": error_code,
+        }
+    }
+    return json.dumps(error_data)

--- a/nemoguardrails/rails/llm/streaming/streaming_output_rails.py
+++ b/nemoguardrails/rails/llm/streaming/streaming_output_rails.py
@@ -82,7 +82,8 @@ async def run_output_rails_in_streaming(
     """
     buffer_strategy = get_buffer_strategy(output_rails_streaming_config)
     output_rails_flows_id = rails.config.rails.output.flows
-    stream_first = stream_first or output_rails_streaming_config.stream_first
+    if stream_first is None:
+        stream_first = output_rails_streaming_config.stream_first
     get_action_details = partial(get_action_details_from_flow_id, flows=rails.config.flows)
 
     parallel_mode = getattr(rails.config.rails.output, "parallel", False)
@@ -179,7 +180,10 @@ async def _run_parallel_output_rails(
         result, status = result_tuple
 
         if status != "success":
-            log.error(f"Parallel rails execution failed with status: {status}")
+            error_message = f"Parallel rails execution failed with status: {status}"
+            log.error(error_message)
+            yield _internal_rail_error("output rails", error_message)
+            return
         else:
             # if there are any stop events, content was blocked or internal error occurred
             result_events = getattr(result, "events", None)
@@ -188,7 +192,10 @@ async def _run_parallel_output_rails(
                 return
 
     except Exception as e:
-        log.error(f"Error in parallel rail execution: {e}")
+        error_message = f"Error in parallel rail execution: {e}"
+        log.error(error_message)
+        yield _internal_rail_error("output rails", error_message)
+        return
 
     # update explain info for parallel mode
     rails._explain_info = rails._ensure_explain_info()
@@ -219,9 +226,16 @@ async def _run_sequential_output_rails(
         action_result = await rails.runtime.action_dispatcher.execute_action(action_name, params)
         rails._explain_info = rails._ensure_explain_info()
 
-        # Use the mapping to decide if the result indicates blocked content.
         action_func = rails.runtime.action_dispatcher.get_action(action_name)
-        if is_output_blocked(action_result, action_func):
+        result, status = _sequential_action_result(action_result)
+        if status != "success":
+            error_message = f"Action {action_name} failed with status: {status}"
+            log.error(error_message)
+            yield _internal_rail_error(flow_id, error_message)
+            return
+
+        # Use the mapping to decide if the result indicates blocked content.
+        if is_output_blocked(result, action_func):
             yield _blocked_output_error(flow_id)
             return
 
@@ -356,6 +370,17 @@ def _internal_rail_error(flow_id: str, error_message: str) -> str:
         }
     }
     return json.dumps(error_data)
+
+
+def _sequential_action_result(action_result: Any) -> tuple[Any, str]:
+    if (
+        isinstance(action_result, tuple)
+        and len(action_result) == 2
+        and isinstance(action_result[1], str)
+        and action_result[1] in {"success", "failed"}
+    ):
+        return action_result
+    return action_result, "success"
 
 
 def _parallel_stop_error(stop_event: dict) -> str:

--- a/tests/rails/llm/test_config_preparation.py
+++ b/tests/rails/llm/test_config_preparation.py
@@ -27,7 +27,7 @@ def test_config_preparation_startup_module_exports_public_helpers():
     ]
 
 
-def test_prepare_llmrails_config_loads_colang_flows_each_time_in_place():
+def test_prepare_llmrails_config_deduplicates_loaded_colang_flows():
     config = RailsConfig(models=[])
 
     first = prepare_llmrails_config(
@@ -42,7 +42,30 @@ def test_prepare_llmrails_config_loads_colang_flows_each_time_in_place():
     assert first.config is config
     assert second.config is config
     assert first_flow_count > 0
-    assert len(config.flows) > first_flow_count
+    assert len(config.flows) == first_flow_count
+
+
+def test_prepare_llmrails_config_can_reload_flows_after_caller_clears_them():
+    config = RailsConfig(models=[])
+
+    prepare_llmrails_config(config=config)
+    flow_count = len(config.flows)
+    config.flows = []
+
+    prepare_llmrails_config(config=config)
+
+    assert len(config.flows) == flow_count
+
+
+def test_prepare_llmrails_config_copy_does_not_duplicate_loaded_flows():
+    config = RailsConfig(models=[])
+
+    prepare_llmrails_config(config=config)
+    flow_count = len(config.flows)
+    prepared = prepare_llmrails_config(config=config, in_place=False)
+
+    assert prepared.config is not config
+    assert len(prepared.config.flows) == flow_count
 
 
 def test_prepare_llmrails_config_marks_rail_flows_each_time():

--- a/tests/rails/llm/test_generation_stream.py
+++ b/tests/rails/llm/test_generation_stream.py
@@ -312,39 +312,27 @@ async def test_generation_token_stream_pushes_error_payload_when_generation_fail
 
 
 @pytest.mark.asyncio
-async def test_generation_token_stream_waits_for_generation_when_consumer_closes_early():
+async def test_generation_token_stream_cancels_generation_when_consumer_closes_early():
     rails = SlowFakeRails()
     stream = generation_token_stream(rails, messages=[{"role": "user", "content": "Hi"}])
 
     assert await stream.__anext__() == "hello"
-    close_task = asyncio.create_task(cast(Any, stream).aclose())
+    await asyncio.wait_for(cast(Any, stream).aclose(), timeout=1)
+    await asyncio.wait_for(rails.cancelled.wait(), timeout=1)
     await asyncio.sleep(0)
 
-    assert not close_task.done()
-    assert not rails.cancelled.is_set()
-
-    rails.release.set()
-    await asyncio.wait_for(close_task, timeout=1)
-
-    assert not rails.cancelled.is_set()
     assert cast(set, getattr(rails, "_active_tasks")) == set()
 
 
 @pytest.mark.asyncio
-async def test_generation_token_stream_waits_for_generation_after_output_rail_error():
+async def test_generation_token_stream_cancels_generation_after_output_rail_error():
     rails = BlockingOutputRailsFakeRails()
     stream = generation_token_stream(rails, messages=[{"role": "user", "content": "Hi"}])
 
-    collect_task = asyncio.create_task(_collect(stream))
+    chunks = await asyncio.wait_for(_collect(stream), timeout=1)
+    await asyncio.wait_for(rails.cancelled.wait(), timeout=1)
     await asyncio.sleep(0)
-
-    assert not collect_task.done()
-    assert not rails.cancelled.is_set()
-
-    rails.release.set()
-    chunks = await asyncio.wait_for(collect_task, timeout=1)
 
     assert len(chunks) == 1
     assert json.loads(chunks[0])["error"]["code"] == "content_blocked"
-    assert not rails.cancelled.is_set()
     assert cast(set, getattr(rails, "_active_tasks")) == set()

--- a/tests/rails/llm/test_generation_stream.py
+++ b/tests/rails/llm/test_generation_stream.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, Optional, cast
+
+import pytest
+
+from nemoguardrails.exceptions import StreamingNotSupportedError
+from nemoguardrails.rails.llm.streaming import generation_stream
+from nemoguardrails.rails.llm.streaming.generation_stream import (
+    generation_token_stream,
+    validate_streaming_with_output_rails,
+)
+from nemoguardrails.streaming import END_OF_STREAM
+
+
+class FakeStreamingHandler:
+    instances = []
+
+    def __init__(self, include_metadata: Optional[bool] = False):
+        self.include_metadata = include_metadata
+        self.queue = asyncio.Queue()
+        self.pushed_chunks = []
+        self.__class__.instances.append(self)
+
+    async def push_chunk(self, chunk):
+        self.pushed_chunks.append(chunk)
+        await self.queue.put(chunk)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        chunk = await self.queue.get()
+        if chunk == END_OF_STREAM:
+            raise StopAsyncIteration
+        return chunk
+
+
+class FakeRuntime:
+    def __init__(self):
+        self.action_dispatcher: Any = None
+        self.llm_task_manager: Any = None
+        self.registered_action_params: dict[str, Any] = {}
+
+
+class FakeRails:
+    def __init__(self, *, streaming=None, output_flows=None, generate_error: bool = False):
+        self.config = SimpleNamespace(
+            rails=SimpleNamespace(
+                output=SimpleNamespace(
+                    flows=output_flows or [],
+                    streaming=streaming,
+                )
+            )
+        )
+        self.generate_error = generate_error
+        self.generate_calls = []
+        self.output_rail_calls = []
+        self._explain_info = None
+        self.runtime = FakeRuntime()
+        self.llm = None
+
+    def _ensure_explain_info(self):
+        return {"explain": True}
+
+    async def generate_async(
+        self,
+        *,
+        prompt=None,
+        messages=None,
+        streaming_handler=None,
+        options=None,
+        state=None,
+    ):
+        self.generate_calls.append(
+            {
+                "prompt": prompt,
+                "messages": messages,
+                "streaming_handler": streaming_handler,
+                "options": options,
+                "state": state,
+            }
+        )
+        if self.generate_error:
+            raise RuntimeError('Error code: 500 - {"error": {"message": "boom"}}')
+        assert streaming_handler is not None
+        await streaming_handler.push_chunk(None)
+        await streaming_handler.push_chunk("hello")
+        await streaming_handler.push_chunk(END_OF_STREAM)
+
+
+class SlowFakeRails(FakeRails):
+    def __init__(self):
+        super().__init__()
+        self.cancelled = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def generate_async(
+        self,
+        *,
+        prompt=None,
+        messages=None,
+        streaming_handler=None,
+        options=None,
+        state=None,
+    ):
+        self.generate_calls.append(
+            {
+                "prompt": prompt,
+                "messages": messages,
+                "streaming_handler": streaming_handler,
+                "options": options,
+                "state": state,
+            }
+        )
+        assert streaming_handler is not None
+        await streaming_handler.push_chunk("hello")
+        try:
+            await self.release.wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+        await streaming_handler.push_chunk(END_OF_STREAM)
+
+
+class BlockingOutputRailsFakeRails(SlowFakeRails):
+    def __init__(self):
+        super().__init__()
+        self.config.rails.output.streaming = SimpleNamespace(enabled=True)
+
+
+async def _collect(iterator):
+    return [chunk async for chunk in iterator]
+
+
+async def _tokens(*chunks) -> AsyncIterator[str]:
+    for chunk in chunks:
+        yield chunk
+
+
+@pytest.fixture(autouse=True)
+def fake_streaming_handler_and_output_rails(monkeypatch):
+    FakeStreamingHandler.instances = []
+    monkeypatch.setattr(generation_stream, "StreamingHandler", FakeStreamingHandler)
+
+    def fake_run_output_rails_in_streaming(
+        rails,
+        streaming_handler,
+        output_rails_streaming_config,
+        prompt=None,
+        messages=None,
+        stream_first=None,
+    ):
+        rails.output_rail_calls.append(
+            {
+                "streaming_handler": streaming_handler,
+                "output_rails_streaming_config": output_rails_streaming_config,
+                "messages": messages,
+                "prompt": prompt,
+                "stream_first": stream_first,
+            }
+        )
+
+        async def _wrapped():
+            async for chunk in streaming_handler:
+                if chunk is None:
+                    continue
+                if isinstance(rails, BlockingOutputRailsFakeRails):
+                    yield json.dumps(
+                        {
+                            "error": {
+                                "message": "Blocked by self check output rails.",
+                                "type": "guardrails_violation",
+                                "param": "self check output",
+                                "code": "content_blocked",
+                            }
+                        }
+                    )
+                    return
+                yield f"wrapped:{chunk}"
+
+        return _wrapped()
+
+    monkeypatch.setattr(
+        generation_stream,
+        "run_output_rails_in_streaming",
+        fake_run_output_rails_in_streaming,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_runs_generation_task_and_tracks_it():
+    rails = FakeRails()
+
+    stream = generation_token_stream(
+        rails,
+        messages=[{"role": "user", "content": "Hi"}],
+        include_metadata=True,
+    )
+    chunks = await _collect(stream)
+    await asyncio.sleep(0)
+
+    assert chunks == ["hello"]
+    assert rails._explain_info == {"explain": True}
+    assert FakeStreamingHandler.instances[0].include_metadata is True
+    assert rails.generate_calls[0]["messages"] == [{"role": "user", "content": "Hi"}]
+    assert rails.generate_calls[0]["streaming_handler"] is FakeStreamingHandler.instances[0]
+    assert cast(set, getattr(rails, "_active_tasks")) == set()
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_honors_deprecated_metadata_flag():
+    rails = FakeRails()
+
+    with pytest.warns(DeprecationWarning, match="include_generation_metadata is deprecated"):
+        stream = generation_token_stream(rails, include_generation_metadata=True)
+
+    await _collect(stream)
+
+    assert FakeStreamingHandler.instances[0].include_metadata is True
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_returns_external_generator_without_output_rails():
+    rails = FakeRails()
+    generator = _tokens("a", "b")
+
+    stream = generation_token_stream(rails, generator=generator)
+
+    assert stream is generator
+    assert await _collect(stream) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_wraps_external_generator_when_output_rail_streaming_enabled():
+    streaming_config = SimpleNamespace(enabled=True)
+    rails = FakeRails(streaming=streaming_config)
+    generator = _tokens("a")
+
+    stream = generation_token_stream(
+        rails,
+        generator=generator,
+        messages=[{"role": "user", "content": "Hi"}],
+        prompt=None,
+    )
+
+    assert await _collect(stream) == ["wrapped:a"]
+    assert rails.output_rail_calls == [
+        {
+            "streaming_handler": generator,
+            "output_rails_streaming_config": streaming_config,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "prompt": None,
+            "stream_first": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_wraps_internal_handler_when_output_rail_streaming_enabled():
+    rails = FakeRails(streaming=SimpleNamespace(enabled=True))
+
+    stream = generation_token_stream(rails, prompt="Hi")
+
+    assert await _collect(stream) == ["wrapped:hello"]
+    assert rails.output_rail_calls[0]["streaming_handler"] is FakeStreamingHandler.instances[0]
+    assert rails.generate_calls[0]["prompt"] == "Hi"
+
+
+def test_validate_streaming_with_output_rails_rejects_non_streaming_output_rails():
+    config = SimpleNamespace(
+        rails=SimpleNamespace(
+            output=SimpleNamespace(
+                flows=["self check output"],
+                streaming=SimpleNamespace(enabled=False),
+            )
+        )
+    )
+
+    with pytest.raises(StreamingNotSupportedError, match="stream_async\\(\\) cannot be used"):
+        validate_streaming_with_output_rails(config)
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_pushes_error_payload_when_generation_fails():
+    rails = FakeRails(generate_error=True)
+
+    chunks = await _collect(generation_token_stream(rails, messages=[]))
+
+    assert len(chunks) == 1
+    assert json.loads(chunks[0]) == {"error": {"message": "boom"}}
+    assert FakeStreamingHandler.instances[0].pushed_chunks == [
+        chunks[0],
+        END_OF_STREAM,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_waits_for_generation_when_consumer_closes_early():
+    rails = SlowFakeRails()
+    stream = generation_token_stream(rails, messages=[{"role": "user", "content": "Hi"}])
+
+    assert await stream.__anext__() == "hello"
+    close_task = asyncio.create_task(cast(Any, stream).aclose())
+    await asyncio.sleep(0)
+
+    assert not close_task.done()
+    assert not rails.cancelled.is_set()
+
+    rails.release.set()
+    await asyncio.wait_for(close_task, timeout=1)
+
+    assert not rails.cancelled.is_set()
+    assert cast(set, getattr(rails, "_active_tasks")) == set()
+
+
+@pytest.mark.asyncio
+async def test_generation_token_stream_waits_for_generation_after_output_rail_error():
+    rails = BlockingOutputRailsFakeRails()
+    stream = generation_token_stream(rails, messages=[{"role": "user", "content": "Hi"}])
+
+    collect_task = asyncio.create_task(_collect(stream))
+    await asyncio.sleep(0)
+
+    assert not collect_task.done()
+    assert not rails.cancelled.is_set()
+
+    rails.release.set()
+    chunks = await asyncio.wait_for(collect_task, timeout=1)
+
+    assert len(chunks) == 1
+    assert json.loads(chunks[0])["error"]["code"] == "content_blocked"
+    assert not rails.cancelled.is_set()
+    assert cast(set, getattr(rails, "_active_tasks")) == set()

--- a/tests/rails/llm/test_llmrails_api_contract.py
+++ b/tests/rails/llm/test_llmrails_api_contract.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 
 import pickle
-from unittest.mock import patch
 
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.context import explain_info_var
+from nemoguardrails.logging.explain import ExplainInfo
 from tests.utils import FakeLLMModel
 
 
@@ -26,7 +27,7 @@ def _config() -> RailsConfig:
     return RailsConfig.from_content(config={"models": []})
 
 
-def test_constructor_keeps_public_state_visible():
+def test_constructor_keeps_public_compatibility_state_visible():
     config = _config()
     llm = FakeLLMModel(responses=[])
 
@@ -36,47 +37,9 @@ def test_constructor_keeps_public_state_visible():
     assert rails.llm is llm
     assert rails.runtime is not None
     assert rails.llm_generation_actions is not None
+    assert rails.embedding_search.providers == {}
     assert rails.events_history_cache == {}
     assert rails.explain_info is None
-
-
-def test_constructor_reports_library_usage():
-    config = _config()
-
-    with patch("nemoguardrails.telemetry.report_usage") as report_usage:
-        LLMRails(config=config, llm=FakeLLMModel(responses=[]))
-
-    report_usage.assert_called_once_with(config, deployment_type="library", rails_engine="LLMRails")
-
-
-def test_config_py_init_embeddings_model_updates_default_search_config(tmp_path):
-    config = _config()
-    config.config_path = str(tmp_path)
-    (tmp_path / "config.py").write_text(
-        """
-from nemoguardrails.rails.llm.config import Model
-
-
-def init(rails):
-    rails.config.models.append(
-        Model(
-            type="embeddings",
-            engine="SentenceTransformers",
-            model="intfloat/e5-large-v2",
-            parameters={"device": "cpu"},
-        )
-    )
-""",
-        encoding="utf-8",
-    )
-
-    rails = LLMRails(config=config, llm=FakeLLMModel(responses=[]))
-
-    assert rails.embedding_search.default_model == "intfloat/e5-large-v2"
-    assert rails.embedding_search.default_engine == "SentenceTransformers"
-    assert rails.embedding_search.default_params == {"device": "cpu"}
-    assert config.core.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
-    assert config.core.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
 
 
 def test_update_llm_keeps_runtime_generation_actions_and_public_attr_in_sync():
@@ -110,11 +73,25 @@ async def test_sync_wrappers_raise_when_called_from_async_loop():
 def test_getstate_serializes_config_only():
     rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
     rails.events_history_cache["cached"] = [{"type": "CachedEvent"}]
+    rails.explain_info = ExplainInfo()
     rails.register_action_param("custom_param", object())
 
     state = rails.__getstate__()
 
     assert state == {"config": rails.config}
+
+
+def test_explain_prefers_active_request_context_over_latest_instance_info():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+    latest_explain_info = ExplainInfo()
+    request_explain_info = ExplainInfo()
+    rails.explain_info = latest_explain_info
+    token = explain_info_var.set(request_explain_info)
+    try:
+        assert rails.explain() is request_explain_info
+        assert rails.explain_info is request_explain_info
+    finally:
+        explain_info_var.reset(token)
 
 
 def test_pickle_round_trip_reinitializes_from_config_without_runtime_state():

--- a/tests/rails/llm/test_llmrails_hardening.py
+++ b/tests/rails/llm/test_llmrails_hardening.py
@@ -1,0 +1,447 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+from copy import deepcopy
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.context import (
+    explain_info_var,
+    generation_options_var,
+    llm_stats_var,
+    raw_llm_request,
+    streaming_handler_var,
+)
+from nemoguardrails.logging.explain import ExplainInfo
+from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.rails.llm.config import Model
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
+from nemoguardrails.streaming import END_OF_STREAM
+from tests.utils import FakeLLMModel
+
+COLANG = """
+define user express greeting
+  "hi"
+
+define flow
+  user express greeting
+  $user_greeted = True
+  bot express greeting
+
+define bot express greeting
+  "Hello there!"
+"""
+
+
+def _config(yaml_content: str | None = None) -> RailsConfig:
+    return RailsConfig.from_content(colang_content=COLANG, yaml_content=yaml_content)
+
+
+def _rails(config: RailsConfig | None = None) -> LLMRails:
+    return LLMRails(config=config or _config(), llm=FakeLLMModel(responses=["  express greeting"]))
+
+
+@pytest.mark.asyncio
+async def test_generate_standard_info_logs_keep_llmrails_logger_name(caplog):
+    with caplog.at_level(logging.INFO):
+        await _rails().generate_async(messages=[{"role": "user", "content": "hi"}])
+
+    total_processing_logs = [record for record in caplog.records if "--- :: Total processing took" in record.message]
+
+    assert [record.name for record in total_processing_logs] == ["nemoguardrails.rails.llm.llmrails"]
+
+
+@pytest.mark.asyncio
+async def test_generate_prompt_and_messages_return_shapes_without_options():
+    prompt_result = await _rails().generate_async(prompt="hi")
+    assert prompt_result == "Hello there!"
+
+    messages_result = await _rails().generate_async(messages=[{"role": "user", "content": "hi"}])
+    assert messages_result == {"role": "assistant", "content": "Hello there!"}
+
+
+@pytest.mark.asyncio
+async def test_generate_options_dict_and_object_return_generation_response():
+    dict_result = await _rails().generate_async(
+        prompt="hi",
+        options={"output_vars": ["user_greeted"]},
+    )
+
+    assert isinstance(dict_result, GenerationResponse)
+    assert dict_result.response == "Hello there!"
+    assert dict_result.output_data == {"user_greeted": True}
+
+    options = GenerationOptions(output_vars=["user_greeted"])
+    object_result = await _rails().generate_async(
+        messages=[{"role": "user", "content": "hi"}],
+        options=options,
+    )
+
+    assert isinstance(object_result, GenerationResponse)
+    assert object_result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert object_result.output_data == {"user_greeted": True}
+
+
+@pytest.mark.asyncio
+async def test_generate_state_forces_generation_response_without_options():
+    state = {"events": []}
+
+    result = await _rails().generate_async(
+        messages=[{"role": "user", "content": "hi"}],
+        state=state,
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert result.state is not None
+    assert "events" in result.state
+    assert state == {"events": []}
+
+
+@pytest.mark.asyncio
+async def test_generate_tracing_enabled_returns_generation_response_without_requested_log():
+    config = _config(
+        yaml_content="""
+tracing:
+  enabled: true
+  adapters: []
+"""
+    )
+
+    result = await _rails(config).generate_async(prompt="hi")
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == "Hello there!"
+    assert result.log is None
+
+
+@pytest.mark.asyncio
+async def test_generate_tracing_does_not_mutate_generation_options_object():
+    config = _config(
+        yaml_content="""
+tracing:
+  enabled: true
+  adapters: []
+"""
+    )
+    options = GenerationOptions()
+
+    result = await _rails(config).generate_async(prompt="hi", options=options)
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == "Hello there!"
+    assert result.log is None
+    assert options.log.activated_rails is False
+    assert options.log.llm_calls is False
+    assert options.log.internal_events is False
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_mutate_input_messages_or_options_dict():
+    messages = [{"role": "user", "content": "hi"}]
+    options = {
+        "rails": ["input", "output", "retrieval", "dialog", "tool_input", "tool_output"],
+        "output_vars": ["user_greeted"],
+    }
+    original_messages = deepcopy(messages)
+    original_options = deepcopy(options)
+
+    result = await _rails().generate_async(messages=messages, options=options)
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert messages == original_messages
+    assert options == original_options
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generate_requests_keep_context_isolated():
+    token_options = generation_options_var.set(None)
+    token_request = raw_llm_request.set(None)
+    snapshots = {}
+    both_requests_started = asyncio.Event()
+
+    async def fake_run_colang_turn(rails, events, state, processing_log):
+        request = cast(list[dict[str, Any]], deepcopy(raw_llm_request.get()))
+        options = cast(GenerationOptions, generation_options_var.get())
+        prompt = request[0]["content"]
+        snapshots[prompt] = {
+            "request": request,
+            "llm_params": deepcopy(options.llm_params),
+        }
+
+        if len(snapshots) == 2:
+            both_requests_started.set()
+
+        await both_requests_started.wait()
+        processing_log.extend(
+            [
+                {"type": "noop", "timestamp": 0.0},
+                {"type": "noop", "timestamp": 0.1},
+            ]
+        )
+        return [
+            {
+                "type": "StartUtteranceBotAction",
+                "script": f"reply {prompt}",
+            }
+        ]
+
+    try:
+        rails = _rails()
+
+        with patch(
+            "nemoguardrails.rails.llm.generation.generation_workflow.run_colang_turn",
+            fake_run_colang_turn,
+        ):
+            first, second = await asyncio.gather(
+                rails.generate_async(
+                    prompt="first",
+                    options={"llm_params": {"request_id": "first"}},
+                ),
+                rails.generate_async(
+                    prompt="second",
+                    options={"llm_params": {"request_id": "second"}},
+                ),
+            )
+
+        first = cast(GenerationResponse, first)
+        second = cast(GenerationResponse, second)
+        assert first.response == "reply first"
+        assert second.response == "reply second"
+        assert snapshots == {
+            "first": {
+                "request": [{"role": "user", "content": "first"}],
+                "llm_params": {"request_id": "first"},
+            },
+            "second": {
+                "request": [{"role": "user", "content": "second"}],
+                "llm_params": {"request_id": "second"},
+            },
+        }
+        assert generation_options_var.get() is None
+        assert raw_llm_request.get() is None
+
+    finally:
+        generation_options_var.reset(token_options)
+        raw_llm_request.reset(token_request)
+
+
+@pytest.mark.asyncio
+async def test_generate_resets_request_context_after_success_in_same_task():
+    outer_options = GenerationOptions(llm_params={"request_id": "outer"})
+    outer_request = [{"role": "user", "content": "outer"}]
+    outer_explain_info = ExplainInfo()
+    outer_stats = LLMStats()
+    token_options = generation_options_var.set(outer_options)
+    token_request = raw_llm_request.set(outer_request)
+    token_explain_info = explain_info_var.set(outer_explain_info)
+    token_stats = llm_stats_var.set(outer_stats)
+    token_streaming_handler = streaming_handler_var.set(None)
+
+    try:
+        result = await _rails().generate_async(
+            prompt="hi",
+            options={"llm_params": {"request_id": "inner"}},
+        )
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == "Hello there!"
+        assert generation_options_var.get() is outer_options
+        assert raw_llm_request.get() is outer_request
+        assert explain_info_var.get() is outer_explain_info
+        assert llm_stats_var.get() is outer_stats
+        assert streaming_handler_var.get() is None
+    finally:
+        streaming_handler_var.reset(token_streaming_handler)
+        llm_stats_var.reset(token_stats)
+        explain_info_var.reset(token_explain_info)
+        raw_llm_request.reset(token_request)
+        generation_options_var.reset(token_options)
+
+
+@pytest.mark.asyncio
+async def test_generate_resets_request_context_after_failure_in_same_task():
+    outer_options = GenerationOptions(llm_params={"request_id": "outer"})
+    outer_request = [{"role": "user", "content": "outer"}]
+    outer_explain_info = ExplainInfo()
+    outer_stats = LLMStats()
+    token_options = generation_options_var.set(outer_options)
+    token_request = raw_llm_request.set(outer_request)
+    token_explain_info = explain_info_var.set(outer_explain_info)
+    token_stats = llm_stats_var.set(outer_stats)
+    token_streaming_handler = streaming_handler_var.set(None)
+
+    async def failing_run_colang_turn(rails, events, state, processing_log):
+        raise RuntimeError("generation failed")
+
+    try:
+        rails = _rails()
+        with patch(
+            "nemoguardrails.rails.llm.generation.generation_workflow.run_colang_turn",
+            failing_run_colang_turn,
+        ):
+            with pytest.raises(RuntimeError, match="generation failed"):
+                await rails.generate_async(
+                    prompt="hi",
+                    options={"llm_params": {"request_id": "inner"}},
+                )
+
+        assert generation_options_var.get() is outer_options
+        assert raw_llm_request.get() is outer_request
+        assert explain_info_var.get() is outer_explain_info
+        assert llm_stats_var.get() is outer_stats
+        assert streaming_handler_var.get() is None
+    finally:
+        streaming_handler_var.reset(token_streaming_handler)
+        llm_stats_var.reset(token_stats)
+        explain_info_var.reset(token_explain_info)
+        raw_llm_request.reset(token_request)
+        generation_options_var.reset(token_options)
+
+
+@pytest.mark.asyncio
+async def test_generate_closes_request_streaming_handler_once_on_success():
+    class StreamingHandler:
+        def __init__(self):
+            self.chunks = []
+
+        async def push_chunk(self, chunk):
+            self.chunks.append(chunk)
+
+    streaming_handler = StreamingHandler()
+
+    result = await _rails().generate_async(
+        prompt="hi",
+        streaming_handler=cast(Any, streaming_handler),
+    )
+
+    assert result == "Hello there!"
+    assert streaming_handler.chunks.count(END_OF_STREAM) == 1
+    assert streaming_handler.chunks[-1] is END_OF_STREAM
+
+
+@pytest.mark.asyncio
+async def test_generate_closes_request_streaming_handler_once_on_failure():
+    class StreamingHandler:
+        def __init__(self):
+            self.chunks = []
+
+        async def push_chunk(self, chunk):
+            self.chunks.append(chunk)
+
+    async def failing_run_colang_turn(rails, events, state, processing_log):
+        raise RuntimeError("generation failed")
+
+    streaming_handler = StreamingHandler()
+
+    with patch(
+        "nemoguardrails.rails.llm.generation.generation_workflow.run_colang_turn",
+        failing_run_colang_turn,
+    ):
+        with pytest.raises(RuntimeError, match="generation failed"):
+            await _rails().generate_async(
+                prompt="hi",
+                streaming_handler=cast(Any, streaming_handler),
+            )
+
+    assert streaming_handler.chunks == [END_OF_STREAM]
+
+
+@pytest.mark.asyncio
+async def test_generate_closes_request_streaming_handler_before_trace_export():
+    order = []
+
+    class StreamingHandler:
+        async def push_chunk(self, chunk):
+            if chunk is END_OF_STREAM:
+                order.append("stream-closed")
+
+    async def export_trace(**kwargs):
+        order.append("trace-exported")
+
+    config = _config(
+        yaml_content="""
+tracing:
+  enabled: true
+  adapters: []
+"""
+    )
+
+    with patch(
+        "nemoguardrails.rails.llm.generation.generation_workflow.export_generation_trace",
+        export_trace,
+    ):
+        result = await _rails(config).generate_async(
+            prompt="hi",
+            streaming_handler=cast(Any, StreamingHandler()),
+        )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == "Hello there!"
+    assert order == ["stream-closed", "trace-exported"]
+
+
+@pytest.mark.asyncio
+async def test_generate_colang_1_writes_implicit_history_cache_when_state_is_none():
+    rails = _rails()
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == {"role": "assistant", "content": "Hello there!"}
+    assert len(rails.events_history_cache) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_colang_1_does_not_write_implicit_history_cache_with_explicit_state():
+    rails = _rails()
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "hi"}],
+        state={"events": []},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == [{"role": "assistant", "content": "Hello there!"}]
+    assert rails.events_history_cache == {}
+
+
+def test_env_api_key_model_kwargs_do_not_write_back_to_config(monkeypatch):
+    monkeypatch.setenv("NGR_TEST_API_KEY", "env-secret")
+    config = RailsConfig(
+        models=[
+            Model(
+                type="main",
+                engine="fake",
+                model="fake",
+                api_key_env_var="NGR_TEST_API_KEY",
+                parameters={"base_url": "https://example.test"},
+            )
+        ]
+    )
+
+    with patch("nemoguardrails.rails.llm.llmrails.init_llm_model") as init_llm:
+        init_llm.return_value = FakeLLMModel(responses=[])
+        LLMRails(config=config)
+
+    init_kwargs = init_llm.call_args.kwargs["kwargs"]
+    assert init_kwargs["api_key"] == "env-secret"
+    assert init_kwargs["base_url"] == "https://example.test"
+    assert config.models[0].parameters == {"base_url": "https://example.test"}

--- a/tests/rails/llm/test_llmrails_startup_boundary.py
+++ b/tests/rails/llm/test_llmrails_startup_boundary.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import ModuleType, SimpleNamespace
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.rails.llm import llmrails
+from nemoguardrails.rails.llm.config import RailsConfig, TracingConfig
+from nemoguardrails.rails.llm.startup.config_preparation import PreparedLLMRailsConfig
+from nemoguardrails.rails.llm.startup.embedding_search import DEFAULT_EMBEDDING_ENGINE, DEFAULT_EMBEDDING_MODEL
+from nemoguardrails.rails.llm.startup.tracing import create_startup_tracing_adapters
+
+
+class RuntimeWithRegistries:
+    def __init__(self):
+        self.llm_task_manager = object()
+        self.registered_action_params = {}
+
+    def register_action_param(self, name, value):
+        self.registered_action_params[name] = value
+
+
+def _prepared_config(config: RailsConfig) -> PreparedLLMRailsConfig:
+    setattr(config, "_prepared_for_startup_test", True)
+    return PreparedLLMRailsConfig(config=config)
+
+
+def test_constructor_startup_order_from_config_preparation_through_kb(monkeypatch):
+    sequence = []
+
+    def prepare_llmrails_config(**kwargs):
+        sequence.append("prepare config")
+        return _prepared_config(kwargs["config"])
+
+    def load_config_py_modules(config):
+        sequence.append("load config.py modules")
+        assert getattr(config, "_prepared_for_startup_test") is True
+        return [ModuleType("config")]
+
+    def runtime_for_colang_version(config, verbose):
+        sequence.append("runtime creation")
+        assert getattr(config, "_prepared_for_startup_test") is True
+        assert verbose is True
+        return RuntimeWithRegistries()
+
+    def run_config_py_init_hooks(rails, config_modules):
+        sequence.append("config.py init hooks")
+        assert len(config_modules) == 1
+        assert getattr(rails.config, "_prepared_for_startup_test") is True
+        assert isinstance(rails.runtime, RuntimeWithRegistries)
+
+    def apply_embedding_model_config(
+        config,
+        default_embedding_model,
+        default_embedding_engine,
+        default_embedding_params,
+    ):
+        sequence.append("embedding config")
+        assert getattr(config, "_prepared_for_startup_test") is True
+        assert default_embedding_model == DEFAULT_EMBEDDING_MODEL
+        assert default_embedding_engine == DEFAULT_EMBEDDING_ENGINE
+        assert default_embedding_params == {}
+        return "prepared-model", "prepared-engine", {"prepared": True}
+
+    def create_log_adapters(tracing_config):
+        sequence.append("tracing adapter creation")
+        assert tracing_config.enabled is True
+        return ["adapter"]
+
+    def validate_config(config):
+        sequence.append("validation")
+
+    def init_llms(rails):
+        sequence.append("LLM/model-cache initialization")
+
+    def register_llm_generation_actions(rails, verbose):
+        sequence.append("generation-action registration")
+        assert verbose is True
+        rails._llm_generation_actions = object()
+
+    def init_knowledge_base(rails):
+        sequence.append("KB initialization")
+        rails._kb = None
+
+    monkeypatch.setattr(llmrails, "prepare_llmrails_config", prepare_llmrails_config)
+    monkeypatch.setattr(llmrails, "load_config_py_modules", load_config_py_modules)
+    monkeypatch.setattr(llmrails, "runtime_for_colang_version", runtime_for_colang_version)
+    monkeypatch.setattr(llmrails, "run_config_py_init_hooks", run_config_py_init_hooks)
+    monkeypatch.setattr(llmrails, "apply_embedding_model_config", apply_embedding_model_config)
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+    monkeypatch.setattr(llmrails, "validate_llmrails_config", validate_config)
+    monkeypatch.setattr(llmrails.LLMRails, "_init_llms", init_llms)
+    monkeypatch.setattr(llmrails, "register_llm_generation_actions", register_llm_generation_actions)
+    monkeypatch.setattr(llmrails, "init_knowledge_base", init_knowledge_base)
+
+    config = RailsConfig(models=[], tracing=TracingConfig(enabled=True))
+
+    rails = llmrails.LLMRails(config, verbose=True)
+
+    assert sequence == [
+        "prepare config",
+        "load config.py modules",
+        "runtime creation",
+        "config.py init hooks",
+        "embedding config",
+        "tracing adapter creation",
+        "validation",
+        "LLM/model-cache initialization",
+        "generation-action registration",
+        "KB initialization",
+    ]
+    assert rails._log_adapters == ["adapter"]
+    assert rails.embedding_search.default_model == "prepared-model"
+    assert rails.embedding_search.default_engine == "prepared-engine"
+    assert rails.embedding_search.default_params == {"prepared": True}
+    assert rails.explain_info is None
+
+
+def test_config_py_hook_sees_prepared_state_and_provider_registration_reaches_later_startup(monkeypatch):
+    provider_seen_by_generation_actions = None
+    provider_seen_by_kb = None
+
+    class CustomProvider(EmbeddingsIndex):
+        pass
+
+    config_module = ModuleType("config")
+
+    def init(app):
+        assert getattr(app.config, "_prepared_for_startup_test") is True
+        assert isinstance(app.runtime, RuntimeWithRegistries)
+        assert app.embedding_search.default_model == DEFAULT_EMBEDDING_MODEL
+        assert app.embedding_search.default_engine == DEFAULT_EMBEDDING_ENGINE
+        assert app.embedding_search.default_params == {}
+        assert app.embedding_search.providers == {}
+        app.register_embedding_search_provider("custom", CustomProvider)
+
+    setattr(config_module, "init", init)
+
+    def register_llm_generation_actions(rails, verbose):
+        nonlocal provider_seen_by_generation_actions
+        del verbose
+        provider_seen_by_generation_actions = rails.embedding_search.providers["custom"]
+        rails._llm_generation_actions = SimpleNamespace()
+
+    def init_knowledge_base(rails):
+        nonlocal provider_seen_by_kb
+        provider_seen_by_kb = rails.embedding_search.providers["custom"]
+        rails._kb = None
+
+    monkeypatch.setattr(llmrails, "prepare_llmrails_config", lambda **kwargs: _prepared_config(kwargs["config"]))
+    monkeypatch.setattr(llmrails, "load_config_py_modules", lambda config: [config_module])
+    monkeypatch.setattr(llmrails, "runtime_for_colang_version", lambda config, verbose: RuntimeWithRegistries())
+    monkeypatch.setattr(llmrails, "validate_llmrails_config", lambda config: None)
+    monkeypatch.setattr(llmrails.LLMRails, "_init_llms", lambda rails: None)
+    monkeypatch.setattr(llmrails, "register_llm_generation_actions", register_llm_generation_actions)
+    monkeypatch.setattr(llmrails, "init_knowledge_base", init_knowledge_base)
+
+    config = RailsConfig(models=[])
+    object.__setattr__(config, "tracing", None)
+
+    rails = llmrails.LLMRails(config)
+
+    assert rails.embedding_search.providers["custom"] is CustomProvider
+    assert provider_seen_by_generation_actions is CustomProvider
+    assert provider_seen_by_kb is CustomProvider
+    assert rails._log_adapters is None
+
+
+def test_tracing_adapters_are_created_after_config_py_init_hooks(monkeypatch):
+    events = []
+    config_module = ModuleType("config")
+
+    def init(app):
+        app.tracing_marker = "hook-ran"
+        events.append("hook")
+
+    setattr(config_module, "init", init)
+
+    def create_log_adapters(tracing_config):
+        assert tracing_config.enabled is True
+        assert events == ["hook"]
+        events.append("tracing")
+        return [{"tracing": tracing_config}]
+
+    monkeypatch.setattr(llmrails, "prepare_llmrails_config", lambda **kwargs: _prepared_config(kwargs["config"]))
+    monkeypatch.setattr(llmrails, "load_config_py_modules", lambda config: [config_module])
+    monkeypatch.setattr(llmrails, "runtime_for_colang_version", lambda config, verbose: RuntimeWithRegistries())
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+    monkeypatch.setattr(llmrails, "validate_llmrails_config", lambda config: None)
+    monkeypatch.setattr(llmrails.LLMRails, "_init_llms", lambda rails: None)
+    monkeypatch.setattr(
+        llmrails,
+        "register_llm_generation_actions",
+        lambda rails, verbose: setattr(rails, "_llm_generation_actions", object()),
+    )
+    monkeypatch.setattr(llmrails, "init_knowledge_base", lambda rails: setattr(rails, "_kb", None))
+
+    config = RailsConfig(models=[], tracing=TracingConfig(enabled=True))
+
+    rails = llmrails.LLMRails(config)
+
+    assert events == ["hook", "tracing"]
+    assert getattr(rails, "tracing_marker") == "hook-ran"
+    assert rails._log_adapters == [{"tracing": config.tracing}]
+
+
+def test_startup_tracing_helper_returns_none_without_tracing_config(monkeypatch):
+    calls = []
+
+    def create_log_adapters(tracing_config):
+        calls.append(tracing_config)
+        return ["adapter"]
+
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+
+    config = RailsConfig(models=[])
+    object.__setattr__(config, "tracing", None)
+
+    assert create_startup_tracing_adapters(config) is None
+    assert calls == []
+
+
+def test_startup_tracing_helper_creates_adapters_when_tracing_config_is_present(monkeypatch):
+    calls = []
+
+    def create_log_adapters(tracing_config):
+        calls.append(tracing_config)
+        return ["adapter"]
+
+    monkeypatch.setattr("nemoguardrails.tracing.create_log_adapters", create_log_adapters)
+
+    config = RailsConfig(models=[], tracing=TracingConfig(enabled=True))
+
+    assert create_startup_tracing_adapters(config) == ["adapter"]
+    assert calls == [config.tracing]

--- a/tests/rails/llm/test_rails_check.py
+++ b/tests/rails/llm/test_rails_check.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemoguardrails.rails.llm.checks.rails_check import check_messages
+from nemoguardrails.rails.llm.options import (
+    ActivatedRail,
+    GenerationLog,
+    GenerationResponse,
+    RailStatus,
+    RailType,
+)
+
+
+class FakeRails:
+    def __init__(self, response):
+        self.config = SimpleNamespace(colang_version="1.0")
+        self.runtime = SimpleNamespace()
+        self.response = response
+        self.generate_calls = []
+
+    async def generate_async(self, *, messages, options):
+        self.generate_calls.append({"messages": messages, "options": options})
+        return self.response
+
+
+class MutatingRails(FakeRails):
+    async def generate_async(self, *, messages, options):
+        messages[0]["content"]["nested"] = "changed"
+        return await super().generate_async(messages=messages, options=options)
+
+
+@pytest.mark.asyncio
+async def test_check_messages_detects_input_rails_and_marks_passed():
+    rails = FakeRails(GenerationResponse(response=[{"role": "user", "content": "hello"}]))
+
+    result = await check_messages(rails, [{"role": "user", "content": "hello"}])
+
+    assert result.status == RailStatus.PASSED
+    assert result.content == "hello"
+    assert rails.generate_calls == [
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "options": {
+                "rails": ["input"],
+                "log": {"activated_rails": True},
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_messages_normalizes_output_only_messages():
+    rails = FakeRails(GenerationResponse(response=[{"role": "assistant", "content": "hello"}]))
+
+    result = await check_messages(rails, [{"role": "assistant", "content": "hello"}])
+
+    assert result.status == RailStatus.PASSED
+    assert rails.generate_calls[0]["messages"] == [
+        {"role": "user", "content": ""},
+        {"role": "assistant", "content": "hello"},
+    ]
+    assert rails.generate_calls[0]["options"]["rails"] == ["output"]
+
+
+@pytest.mark.asyncio
+async def test_check_messages_honors_explicit_rail_types_and_reports_modified_content():
+    rails = FakeRails(GenerationResponse(response=[{"role": "assistant", "content": "updated"}]))
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "original"},
+    ]
+
+    result = await check_messages(rails, messages, rail_types=[RailType.OUTPUT])
+
+    assert result.status == RailStatus.MODIFIED
+    assert result.content == "updated"
+    assert rails.generate_calls[0]["messages"] == messages
+    assert rails.generate_calls[0]["options"]["rails"] == ["output"]
+
+
+@pytest.mark.asyncio
+async def test_check_messages_does_not_expose_caller_messages_to_generation_mutation():
+    rails = MutatingRails(GenerationResponse(response=[{"role": "user", "content": "hello"}]))
+    messages = [
+        {"role": "context", "content": {"nested": "original"}},
+        {"role": "user", "content": "hello"},
+    ]
+
+    result = await check_messages(rails, messages)
+
+    assert result.status == RailStatus.PASSED
+    assert messages == [
+        {"role": "context", "content": {"nested": "original"}},
+        {"role": "user", "content": "hello"},
+    ]
+    assert rails.generate_calls[0]["messages"][0]["content"] == {"nested": "changed"}
+
+
+@pytest.mark.asyncio
+async def test_check_messages_reports_first_blocking_rail():
+    rails = FakeRails(
+        GenerationResponse(
+            response="blocked",
+            log=GenerationLog(
+                activated_rails=[
+                    ActivatedRail(type="input", name="first rail", stop=False),
+                    ActivatedRail(type="output", name="blocking rail", stop=True),
+                ]
+            ),
+        )
+    )
+
+    result = await check_messages(rails, [{"role": "user", "content": "hello"}])
+
+    assert result.status == RailStatus.BLOCKED
+    assert result.content == "blocked"
+    assert result.rail == "blocking rail"
+
+
+@pytest.mark.asyncio
+async def test_check_messages_rejects_unexpected_generation_response_type():
+    rails = FakeRails("not a generation response")
+
+    with pytest.raises(RuntimeError, match="Expected GenerationResponse, got str"):
+        await check_messages(rails, [{"role": "user", "content": "hello"}])

--- a/tests/rails/llm/test_streaming_output_rails.py
+++ b/tests/rails/llm/test_streaming_output_rails.py
@@ -293,7 +293,7 @@ async def test_output_rails_stream_yields_block_error_for_sequential_rails(monke
 
 
 @pytest.mark.asyncio
-async def test_output_rails_stream_uses_config_stream_first_when_explicit_false(monkeypatch):
+async def test_output_rails_stream_honors_explicit_stream_first_false(monkeypatch):
     _patch_buffer_strategy(
         monkeypatch,
         [ChunkBatch(processing_context=["blocked"], user_output_chunks=["blocked"])],
@@ -311,9 +311,8 @@ async def test_output_rails_stream_uses_config_stream_first_when_explicit_false(
         )
     )
 
-    assert len(chunks) == 2
-    assert chunks[0] == "blocked"
-    assert json.loads(chunks[1])["error"]["code"] == "content_blocked"
+    assert len(chunks) == 1
+    assert json.loads(chunks[0])["error"]["code"] == "content_blocked"
 
 
 @pytest.mark.asyncio
@@ -354,7 +353,7 @@ async def test_output_rails_stream_closes_external_generator_when_consumer_close
 
 
 @pytest.mark.asyncio
-async def test_output_rails_stream_continues_for_sequential_action_failure(monkeypatch):
+async def test_output_rails_stream_yields_internal_error_for_sequential_action_failure(monkeypatch):
     _patch_buffer_strategy(
         monkeypatch,
         [ChunkBatch(processing_context=["unsafe"], user_output_chunks=["unsafe"])],
@@ -371,7 +370,15 @@ async def test_output_rails_stream_continues_for_sequential_action_failure(monke
         )
     )
 
-    assert chunks == ["unsafe"]
+    assert len(chunks) == 1
+    assert json.loads(chunks[0]) == {
+        "error": {
+            "message": "Internal error in self check output rail: Action self_check_output failed with status: failed",
+            "type": "internal_error",
+            "param": "self check output",
+            "code": "rail_execution_failure",
+        }
+    }
     assert rails._explain_info == {"ensured": 1}
 
 
@@ -432,7 +439,7 @@ async def test_output_rails_stream_yields_parallel_stop_event_error(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_output_rails_stream_continues_for_parallel_action_failure(monkeypatch):
+async def test_output_rails_stream_yields_internal_error_for_parallel_action_failure(monkeypatch):
     _patch_buffer_strategy(
         monkeypatch,
         [ChunkBatch(processing_context=["unsafe"], user_output_chunks=["unsafe"])],
@@ -449,12 +456,19 @@ async def test_output_rails_stream_continues_for_parallel_action_failure(monkeyp
         )
     )
 
-    assert chunks == ["unsafe"]
-    assert rails._explain_info == {"ensured": 1}
+    assert len(chunks) == 1
+    assert json.loads(chunks[0]) == {
+        "error": {
+            "message": "Internal error in output rails rail: Parallel rails execution failed with status: failed",
+            "type": "internal_error",
+            "param": "output rails",
+            "code": "rail_execution_failure",
+        }
+    }
 
 
 @pytest.mark.asyncio
-async def test_output_rails_stream_continues_for_parallel_exception(monkeypatch):
+async def test_output_rails_stream_yields_internal_error_for_parallel_exception(monkeypatch):
     _patch_buffer_strategy(
         monkeypatch,
         [ChunkBatch(processing_context=["unsafe"], user_output_chunks=["unsafe"])],
@@ -471,5 +485,12 @@ async def test_output_rails_stream_continues_for_parallel_exception(monkeypatch)
         )
     )
 
-    assert chunks == ["unsafe"]
-    assert rails._explain_info == {"ensured": 1}
+    assert len(chunks) == 1
+    assert json.loads(chunks[0]) == {
+        "error": {
+            "message": "Internal error in output rails rail: Error in parallel rail execution: parallel boom",
+            "type": "internal_error",
+            "param": "output rails",
+            "code": "rail_execution_failure",
+        }
+    }

--- a/tests/rails/llm/test_streaming_output_rails.py
+++ b/tests/rails/llm/test_streaming_output_rails.py
@@ -1,0 +1,475 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, cast
+
+import pytest
+
+from nemoguardrails.rails.llm.buffer import ChunkBatch
+from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig
+from nemoguardrails.rails.llm.streaming import streaming_output_rails
+from nemoguardrails.rails.llm.streaming.streaming_output_rails import (
+    run_output_rails_in_streaming,
+)
+
+
+class FakeBufferStrategy:
+    def __init__(self, batches: list[ChunkBatch]):
+        self.batches = batches
+
+    async def __call__(self, streaming_handler: AsyncIterator[str]) -> AsyncIterator[ChunkBatch]:
+        del streaming_handler
+        for batch in self.batches:
+            yield batch
+
+    def format_chunks(self, chunks: list[str]) -> str:
+        return "".join(chunks)
+
+
+class FakeActionDispatcher:
+    def __init__(
+        self,
+        *,
+        result: Any = True,
+        status: str = "success",
+        parallel_result: Any = None,
+        parallel_status: str = "success",
+        parallel_exception: Exception | None = None,
+    ):
+        self.result = result
+        self.status = status
+        self.parallel_result = parallel_result
+        self.parallel_status = parallel_status
+        self.parallel_exception = parallel_exception
+        self.calls = []
+
+    async def execute_action(self, action_name: str, params: dict[str, Any]):
+        self.calls.append((action_name, params))
+
+        if action_name == "run_output_rails_in_parallel_streaming":
+            if self.parallel_exception:
+                raise self.parallel_exception
+            return self.parallel_result, self.parallel_status
+
+        return self.result, self.status
+
+    def get_action(self, action_name: str):
+        del action_name
+        return SimpleNamespace(action_meta={})
+
+
+class FakeRuntime:
+    action_dispatcher: FakeActionDispatcher
+    llm_task_manager: Any
+    registered_action_params: dict[str, Any]
+
+    def __init__(self, dispatcher: FakeActionDispatcher):
+        self.action_dispatcher = dispatcher
+        self.llm_task_manager = "task-manager"
+        self.registered_action_params = {
+            "llms": {"main": "registered-llm"},
+            "self_check_output_llm": "rail-llm",
+        }
+
+
+class FakeRails:
+    def __init__(self, dispatcher: FakeActionDispatcher, *, parallel: bool = False):
+        self.config = SimpleNamespace(
+            flows=[],
+            rails=SimpleNamespace(
+                output=SimpleNamespace(
+                    flows=["self check output"],
+                    parallel=parallel,
+                )
+            ),
+        )
+        self.runtime = FakeRuntime(dispatcher)
+        self.llm = "main-llm"
+        self._explain_info = None
+        self.ensure_explain_info_calls = 0
+
+    def _ensure_explain_info(self):
+        self.ensure_explain_info_calls += 1
+        return {"ensured": self.ensure_explain_info_calls}
+
+
+async def _empty_stream() -> AsyncIterator[str]:
+    if False:
+        yield ""
+
+
+async def _tracked_stream(closed: Any, *chunks: str) -> AsyncIterator[str]:
+    try:
+        for chunk in chunks:
+            yield chunk
+            await asyncio.sleep(0)
+    finally:
+        closed.set()
+
+
+async def _collect(iterator: AsyncIterator[str]) -> list[str]:
+    return [chunk async for chunk in iterator]
+
+
+def _patch_buffer_strategy(monkeypatch, batches: list[ChunkBatch]) -> FakeBufferStrategy:
+    strategy = FakeBufferStrategy(batches)
+    monkeypatch.setattr(streaming_output_rails, "get_buffer_strategy", lambda config: strategy)
+    return strategy
+
+
+def _patch_action_details(monkeypatch):
+    def fake_get_action_details_from_flow_id(flow_id: str, flows: list):
+        del flow_id, flows
+        return (
+            "self_check_output",
+            {
+                "bot_response": "$bot_message",
+                "user_input": "$user_message",
+                "literal": "value",
+            },
+        )
+
+    monkeypatch.setattr(
+        streaming_output_rails,
+        "get_action_details_from_flow_id",
+        fake_get_action_details_from_flow_id,
+    )
+
+
+def _patch_shared_action_details(monkeypatch, action_params: dict):
+    def fake_get_action_details_from_flow_id(flow_id: str, flows: list):
+        del flow_id, flows
+        return "self_check_output", action_params
+
+    monkeypatch.setattr(
+        streaming_output_rails,
+        "get_action_details_from_flow_id",
+        fake_get_action_details_from_flow_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_runs_sequential_rails_before_yielding(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["He", "llo"], user_output_chunks=["He", "llo"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(result=True)
+    rails = FakeRails(dispatcher)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+            messages=[
+                {"role": "context", "content": {"account_type": "enterprise"}},
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+    )
+
+    assert chunks == ["He", "llo"]
+    assert dispatcher.calls[0][0] == "self_check_output"
+    params = dispatcher.calls[0][1]
+    assert params["bot_response"] == "Hello"
+    assert params["user_input"] == {"role": "user", "content": "Hi"}
+    assert params["literal"] == "value"
+    assert params["context"] == {
+        "account_type": "enterprise",
+        "bot_message": "Hello",
+        "user_message": {"role": "user", "content": "Hi"},
+    }
+    assert params["llm_task_manager"] == "task-manager"
+    assert params["llms"] == {"main": "registered-llm"}
+    assert params["llm"] == "rail-llm"
+    assert rails._explain_info == {"ensured": 1}
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_does_not_mutate_action_param_templates(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["He", "llo"], user_output_chunks=["He", "llo"])],
+    )
+    shared_action_params = {
+        "bot_response": "$bot_message",
+        "user_input": "$user_message",
+    }
+    _patch_shared_action_details(monkeypatch, shared_action_params)
+    dispatcher = FakeActionDispatcher(result=True)
+    rails = FakeRails(dispatcher)
+
+    await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+    )
+
+    assert shared_action_params == {
+        "bot_response": "$bot_message",
+        "user_input": "$user_message",
+    }
+    assert dispatcher.calls[0][1]["bot_response"] == "Hello"
+    assert dispatcher.calls[0][1]["user_input"] == {"role": "user", "content": "Hi"}
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_passes_through_json_error_chunks(monkeypatch):
+    error_chunk = '{"error": {"message": "upstream failure"}}'
+    _patch_buffer_strategy(
+        monkeypatch,
+        [
+            ChunkBatch(
+                processing_context=[],
+                user_output_chunks=cast(Any, error_chunk),
+            )
+        ],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher()
+    rails = FakeRails(dispatcher)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+        )
+    )
+
+    assert chunks == [error_chunk]
+    assert dispatcher.calls == []
+    assert rails._explain_info is None
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_yields_block_error_for_sequential_rails(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["blocked"], user_output_chunks=["blocked"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(result=False)
+    rails = FakeRails(dispatcher)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+        )
+    )
+
+    assert len(chunks) == 1
+    assert json.loads(chunks[0]) == {
+        "error": {
+            "message": "Blocked by self check output rails.",
+            "type": "guardrails_violation",
+            "param": "self check output",
+            "code": "content_blocked",
+        }
+    }
+    assert rails._explain_info == {"ensured": 1}
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_uses_config_stream_first_when_explicit_false(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["blocked"], user_output_chunks=["blocked"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(result=False)
+    rails = FakeRails(dispatcher)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=True),
+            stream_first=False,
+        )
+    )
+
+    assert len(chunks) == 2
+    assert chunks[0] == "blocked"
+    assert json.loads(chunks[1])["error"]["code"] == "content_blocked"
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_closes_external_generator_after_block(monkeypatch):
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(result=False)
+    rails = FakeRails(dispatcher)
+    closed = asyncio.Event()
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _tracked_stream(closed, "blocked", "unused"),
+            OutputRailsStreamingConfig(stream_first=False, chunk_size=1, context_size=0),
+        )
+    )
+    await asyncio.wait_for(closed.wait(), timeout=1)
+
+    assert len(chunks) == 1
+    assert json.loads(chunks[0])["error"]["code"] == "content_blocked"
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_closes_external_generator_when_consumer_closes(monkeypatch):
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(result=True)
+    rails = FakeRails(dispatcher)
+    closed = asyncio.Event()
+    stream = run_output_rails_in_streaming(
+        rails,
+        _tracked_stream(closed, "first", "unused"),
+        OutputRailsStreamingConfig(stream_first=False, chunk_size=1, context_size=0),
+    )
+
+    assert await stream.__anext__() == "first"
+    await asyncio.wait_for(cast(Any, stream).aclose(), timeout=1)
+    await asyncio.wait_for(closed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_continues_for_sequential_action_failure(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["unsafe"], user_output_chunks=["unsafe"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(result=None, status="failed")
+    rails = FakeRails(dispatcher)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+        )
+    )
+
+    assert chunks == ["unsafe"]
+    assert rails._explain_info == {"ensured": 1}
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_yields_parallel_stop_event_error(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["He", "llo"], user_output_chunks=["He", "llo"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(
+        parallel_result=SimpleNamespace(
+            events=[
+                {
+                    "flow_id": "self check output",
+                    "error_type": "internal_error",
+                    "error_message": "action failed",
+                }
+            ]
+        )
+    )
+    rails = FakeRails(dispatcher, parallel=True)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+            prompt="Hi",
+            messages=[{"role": "context", "content": {"account_type": "enterprise"}}],
+        )
+    )
+
+    assert len(chunks) == 1
+    assert json.loads(chunks[0]) == {
+        "error": {
+            "message": "Internal error in self check output rail: action failed",
+            "type": "internal_error",
+            "param": "self check output",
+            "code": "rail_execution_failure",
+        }
+    }
+    action_name, params = dispatcher.calls[0]
+    assert action_name == "run_output_rails_in_parallel_streaming"
+    assert params["events"] == [
+        {
+            "type": "ContextUpdate",
+            "data": {
+                "account_type": "enterprise",
+                "bot_message": "Hello",
+                "user_message": "Hi",
+            },
+        },
+        {"type": "BotMessage", "text": "Hello"},
+    ]
+    assert params["flows_with_params"]["self check output"]["action_name"] == "self_check_output"
+    assert params["flows_with_params"]["self check output"]["params"]["bot_response"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_continues_for_parallel_action_failure(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["unsafe"], user_output_chunks=["unsafe"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(parallel_status="failed")
+    rails = FakeRails(dispatcher, parallel=True)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+        )
+    )
+
+    assert chunks == ["unsafe"]
+    assert rails._explain_info == {"ensured": 1}
+
+
+@pytest.mark.asyncio
+async def test_output_rails_stream_continues_for_parallel_exception(monkeypatch):
+    _patch_buffer_strategy(
+        monkeypatch,
+        [ChunkBatch(processing_context=["unsafe"], user_output_chunks=["unsafe"])],
+    )
+    _patch_action_details(monkeypatch)
+    dispatcher = FakeActionDispatcher(parallel_exception=RuntimeError("parallel boom"))
+    rails = FakeRails(dispatcher, parallel=True)
+
+    chunks = await _collect(
+        run_output_rails_in_streaming(
+            rails,
+            _empty_stream(),
+            OutputRailsStreamingConfig(stream_first=False),
+        )
+    )
+
+    assert chunks == ["unsafe"]
+    assert rails._explain_info == {"ensured": 1}

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -18,7 +18,7 @@ import logging
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
-from nemoguardrails.rails.llm.llmrails import (
+from nemoguardrails.rails.llm.checks.rails_check import (
     _determine_rails_from_messages,
     _get_blocking_rail,
     _get_last_content_by_role,

--- a/tests/test_system_message_conversion.py
+++ b/tests/test_system_message_conversion.py
@@ -16,6 +16,7 @@
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.rails.llm.conversation.conversation_events import events_for_messages
 from tests.utils import FakeLLMModel
 
 
@@ -44,7 +45,7 @@ async def test_system_message_conversion_v1():
         {"role": "user", "content": "Hello!"},
     ]
 
-    events = llm_rails._get_events_for_messages(messages, None)
+    events = events_for_messages(llm_rails, messages, None)
 
     system_messages = [event for event in events if event["type"] == "SystemMessage"]
     assert len(system_messages) == 1
@@ -76,7 +77,7 @@ async def test_system_message_conversion_v2x():
         {"role": "user", "content": "Hello!"},
     ]
 
-    events = llm_rails._get_events_for_messages(messages, None)
+    events = events_for_messages(llm_rails, messages, None)
 
     system_messages = [event for event in events if event["type"] == "SystemMessage"]
     assert len(system_messages) == 1
@@ -108,7 +109,7 @@ async def test_system_message_conversion_multiple():
         {"role": "user", "content": "Hello!"},
     ]
 
-    events = llm_rails._get_events_for_messages(messages, None)
+    events = events_for_messages(llm_rails, messages, None)
 
     system_messages = [event for event in events if event["type"] == "SystemMessage"]
     assert len(system_messages) == 2

--- a/tests/test_token_usage_integration.py
+++ b/tests/test_token_usage_integration.py
@@ -25,7 +25,6 @@ Note about token usage testing:
 import pytest
 
 from nemoguardrails import RailsConfig
-from nemoguardrails.context import llm_stats_var
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from tests.utils import TestChat
 
@@ -284,12 +283,15 @@ async def test_token_usage_not_set_for_unsupported_provider():
         token_usage=token_usage_data,
     )
 
-    result = await chat.app.generate_async(messages=[{"role": "user", "content": "Hi!"}])
+    # Read the per-call stats from the response log rather than the request-scoped
+    # llm_stats_var contextvar, which generation_context now resets on request close.
+    result = await chat.app.generate_async(
+        messages=[{"role": "user", "content": "Hi!"}],
+        options={"log": {"llm_calls": True}},
+    )
 
-    assert result["content"] == "Hello there!"
+    assert result.response[-1]["content"] == "Hello there!"
 
-    llm_stats = llm_stats_var.get()
-
-    assert llm_stats is not None
-    assert llm_stats.get_stat("total_tokens") == 0
-    assert llm_stats.get_stat("total_calls") == 1
+    assert result.log is not None
+    assert result.log.stats.llm_calls_total_tokens == 0
+    assert result.log.stats.llm_calls_count == 1


### PR DESCRIPTION
Draft tracking PR for deferred follow-ups on top of the LLMRails decomposition stack.

No review needed yet. This PR is fork-only and is here so the intentional behavior changes stay visible while the main stack remains refactor-focused.

Stack base:
- #38 public contract tests
- #39 startup wiring
- #40 runtime conversation flow
- #41 generation workflow
- #42 streaming workflow
- #43 rail checks

Included follow-ups:
- Isolate streaming policy changes that were removed from the pure streaming extraction PR.
- Avoid duplicate Colang flow loading during repeated config preparation.

Intentional behavior change:
- Colang startup flow loading now deduplicates by flow id/name.
- Existing config/user flows win over built-in default/library flows on id collision.
- This differs from develop, which appended duplicate prepared flows on repeated `LLMRails(config)` construction.
- The change is intentionally isolated here instead of being hidden inside the startup refactor.

Validation:
- `poetry run pytest tests/rails/llm/test_generation_stream.py tests/rails/llm/test_streaming_output_rails.py tests/rails/llm/test_config_preparation.py tests/rails/llm/test_colang_flows.py -q`
- `poetry run pre-commit run --all-files`
