### PR TITLE
refactor(llmrails): consolidate extracted module contracts (7/9)

### DIFF
--- a/nemoguardrails/rails/llm/checks/rails_check.py
+++ b/nemoguardrails/rails/llm/checks/rails_check.py
@@ -18,7 +18,7 @@
 import logging
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, List, Optional, Protocol
+from typing import List, Optional
 
 from nemoguardrails.rails.llm.options import (
     GenerationResponse,
@@ -26,22 +26,11 @@ from nemoguardrails.rails.llm.options import (
     RailStatus,
     RailType,
 )
+from nemoguardrails.rails.llm.types import RailsCheckSurface
 
 log = logging.getLogger(__name__)
 
-__all__ = ["RailsCheckRuntime", "check_messages"]
-
-
-class RailsCheckRuntime(Protocol):
-    config: Any
-    runtime: Any
-
-    async def generate_async(
-        self,
-        *,
-        messages: List[dict],
-        options: dict,
-    ) -> object: ...
+__all__ = ["RailsCheckSurface", "check_messages"]
 
 
 @dataclass
@@ -52,7 +41,7 @@ class RailsCheckPlan:
 
 
 async def check_messages(
-    rails: RailsCheckRuntime,
+    rails: RailsCheckSurface,
     messages: List[dict],
     rail_types: Optional[List[RailType]] = None,
 ) -> RailsResult:

--- a/nemoguardrails/rails/llm/conversation/conversation_events.py
+++ b/nemoguardrails/rails/llm/conversation/conversation_events.py
@@ -16,25 +16,18 @@
 """Conversation message conversion to Colang events."""
 
 from collections.abc import MutableMapping
-from typing import Any, List, Protocol
+from typing import Any, List
 
 from nemoguardrails.colang.v2_x.runtime.flows import Action
+from nemoguardrails.rails.llm.types import ConversationEventSurface
 from nemoguardrails.rails.llm.utils import get_history_cache_key
 from nemoguardrails.utils import new_event_dict, new_uuid
 
 __all__ = [
-    "ConversationEventRails",
+    "ConversationEventSurface",
     "events_for_messages",
     "events_history_cache_prefix",
 ]
-
-
-class ConversationEventRails(Protocol):
-    @property
-    def config(self) -> Any: ...
-
-    @property
-    def events_history_cache(self) -> MutableMapping[str, list[dict]]: ...
 
 
 def events_history_cache_prefix(
@@ -58,7 +51,7 @@ def events_history_cache_prefix(
     return 0, []
 
 
-def events_for_messages(rails: ConversationEventRails, messages: List[dict], state: Any) -> List[dict]:
+def events_for_messages(rails: ConversationEventSurface, messages: List[dict], state: Any) -> List[dict]:
     """Return Colang events corresponding to OpenAI-style messages."""
     events = []
 

--- a/nemoguardrails/rails/llm/generation/generation_workflow.py
+++ b/nemoguardrails/rails/llm/generation/generation_workflow.py
@@ -15,7 +15,7 @@
 
 import logging
 import time
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from nemoguardrails.actions.llm.utils import get_colang_history
 from nemoguardrails.colang.v2_x.runtime.flows import State
@@ -36,15 +36,16 @@ from nemoguardrails.rails.llm.generation.generation_tracing import (
 )
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from nemoguardrails.rails.llm.runtime.colang_turns import run_colang_turn
+from nemoguardrails.rails.llm.types import StandardGenerationSurface
 from nemoguardrails.rails.llm.utils import get_history_cache_key
 
 __all__ = ["generate_standard_async"]
 
-log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+log = logging.getLogger(__name__)
 
 
 async def generate_standard_async(
-    rails: Any,
+    rails: StandardGenerationSurface,
     *,
     prompt: Optional[str],
     messages: list[dict],

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -110,8 +110,10 @@ class LLMRails(BaseGuardrails):
     embedding_search: EmbeddingSearchState
     _explain_info: Optional[ExplainInfo]
     _kb: Any
+    _log_adapters: Any
     _llm_generation_actions: Any
     _verbose: bool
+    events_history_cache: dict[str, list[dict]]
     llm: Optional[LLMModel]
     runtime: Runtime
 

--- a/nemoguardrails/rails/llm/runtime/colang_turns.py
+++ b/nemoguardrails/rails/llm/runtime/colang_turns.py
@@ -19,13 +19,14 @@ import asyncio
 import json
 import logging
 import time
-from typing import Any, List, Optional, Protocol, Tuple, Union, cast
+from typing import Any, List, Optional, Tuple, Union, cast
 
 from nemoguardrails.actions.llm.utils import get_colang_history
 from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
 from nemoguardrails.context import llm_stats_var, streaming_handler_var
 from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.rails.llm.types import ColangTurnSurface
 from nemoguardrails.streaming import END_OF_STREAM
 from nemoguardrails.utils import extract_error_json
 
@@ -34,7 +35,7 @@ log = logging.getLogger(__name__)
 process_events_semaphore = asyncio.Semaphore(1)
 
 __all__ = [
-    "ColangTurnRails",
+    "ColangTurnSurface",
     "generate_colang_events",
     "process_colang_events",
     "process_events_semaphore",
@@ -42,19 +43,8 @@ __all__ = [
 ]
 
 
-class ColangTurnRails(Protocol):
-    @property
-    def config(self) -> Any: ...
-
-    @property
-    def runtime(self) -> Any: ...
-
-    @property
-    def verbose(self) -> bool: ...
-
-
 async def run_colang_turn(
-    rails: ColangTurnRails,
+    rails: ColangTurnSurface,
     events: List[dict],
     state: Any,
     processing_log: List[dict],
@@ -66,7 +56,7 @@ async def run_colang_turn(
 
 
 async def _run_colang_1_turn(
-    rails: ColangTurnRails,
+    rails: ColangTurnSurface,
     events: List[dict],
     state: Any,
     processing_log: List[dict],
@@ -94,7 +84,7 @@ async def _run_colang_1_turn(
 
 
 async def _run_colang_2_turn(
-    rails: ColangTurnRails,
+    rails: ColangTurnSurface,
     events: List[dict],
     state: Any,
 ) -> List[dict]:
@@ -113,7 +103,7 @@ async def _run_colang_2_turn(
     return new_events
 
 
-async def generate_colang_events(rails: ColangTurnRails, events: List[dict]) -> List[dict]:
+async def generate_colang_events(rails: ColangTurnSurface, events: List[dict]) -> List[dict]:
     """Generate the next Colang 1.0 events for an event history."""
     t0 = time.time()
 
@@ -138,7 +128,7 @@ async def generate_colang_events(rails: ColangTurnRails, events: List[dict]) -> 
 
 
 async def process_colang_events(
-    rails: ColangTurnRails,
+    rails: ColangTurnSurface,
     events: List[dict],
     state: Union[Optional[dict], State] = None,
     blocking: bool = False,

--- a/nemoguardrails/rails/llm/startup/colang_flows.py
+++ b/nemoguardrails/rails/llm/startup/colang_flows.py
@@ -29,7 +29,7 @@ from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id
 from nemoguardrails.exceptions import InvalidRailsConfigurationError
 from nemoguardrails.rails.llm.config import RailsConfig
 
-log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+log = logging.getLogger(__name__)
 
 _NEMOGUARDRAILS_PACKAGE = "nemoguardrails"
 

--- a/nemoguardrails/rails/llm/startup/generation_actions.py
+++ b/nemoguardrails/rails/llm/startup/generation_actions.py
@@ -15,14 +15,14 @@
 
 """LLM generation action registration."""
 
-from typing import Any, Protocol, Type
+from typing import Any, Type
 
 from nemoguardrails.actions.llm.generation import LLMGenerationActions
 from nemoguardrails.actions.v2_x.generation import LLMGenerationActionsV2dotx
+from nemoguardrails.rails.llm.types import GenerationActionsSurface
 
 __all__ = [
-    "GenerationActionRails",
-    "GenerationActionRuntime",
+    "GenerationActionsSurface",
     "LLMGenerationActions",
     "LLMGenerationActionsV2dotx",
     "generation_actions_class_for_colang_version",
@@ -30,34 +30,12 @@ __all__ = [
 ]
 
 
-class GenerationActionRuntime(Protocol):
-    @property
-    def llm_task_manager(self) -> Any: ...
-
-    def register_actions(self, actions_obj: Any, /, override: bool = True) -> None: ...
-
-
-class GenerationActionRails(Protocol):
-    _llm_generation_actions: Any
-
-    @property
-    def config(self) -> Any: ...
-
-    @property
-    def llm(self) -> Any: ...
-
-    @property
-    def runtime(self) -> GenerationActionRuntime: ...
-
-    def _get_embeddings_search_provider_instance(self, esp_config: Any = None) -> Any: ...
-
-
 def generation_actions_class_for_colang_version(colang_version: str) -> Type[Any]:
     """Return the LLM generation actions class selected by the Colang version."""
     return LLMGenerationActions if colang_version == "1.0" else LLMGenerationActionsV2dotx
 
 
-def register_llm_generation_actions(rails: GenerationActionRails, verbose: bool) -> None:
+def register_llm_generation_actions(rails: GenerationActionsSurface, verbose: bool) -> None:
     """Create and register the LLM generation actions for an LLMRails instance."""
     llm_generation_actions_class = generation_actions_class_for_colang_version(rails.config.colang_version)
     rails._llm_generation_actions = llm_generation_actions_class(

--- a/nemoguardrails/rails/llm/startup/knowledge_base.py
+++ b/nemoguardrails/rails/llm/startup/knowledge_base.py
@@ -23,6 +23,7 @@ from nemoguardrails.embeddings.index import EmbeddingsIndex
 from nemoguardrails.kb.kb import KnowledgeBase
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
+from nemoguardrails.rails.llm.types import KnowledgeBaseSurface
 from nemoguardrails.utils import get_or_create_event_loop
 
 __all__ = ["build_knowledge_base_for_docs", "init_knowledge_base"]
@@ -47,7 +48,7 @@ async def build_knowledge_base_for_docs(
     return kb
 
 
-def init_knowledge_base(rails) -> None:
+def init_knowledge_base(rails: KnowledgeBaseSurface) -> None:
     """Initialize and register the LLMRails knowledge base."""
     rails._kb = None
 

--- a/nemoguardrails/rails/llm/startup/llm_action_caches.py
+++ b/nemoguardrails/rails/llm/startup/llm_action_caches.py
@@ -16,30 +16,19 @@
 """LLM action model caches."""
 
 import logging
-from typing import Dict, Protocol
+from typing import Dict
 
 from nemoguardrails.llm.cache import CacheInterface, LFUCache
 from nemoguardrails.rails.llm.config import Model, RailsConfig
+from nemoguardrails.rails.llm.types import LLMActionCacheSurface
 
-log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+log = logging.getLogger(__name__)
 
 __all__ = [
     "build_llm_action_cache",
     "build_llm_action_caches",
     "initialize_llm_action_caches",
 ]
-
-
-class LLMActionCacheRuntime(Protocol):
-    def register_action_param(self, name: str, value: object) -> None: ...
-
-
-class LLMActionCacheRails(Protocol):
-    @property
-    def config(self) -> RailsConfig: ...
-
-    @property
-    def runtime(self) -> LLMActionCacheRuntime: ...
 
 
 def build_llm_action_cache(model: Model) -> LFUCache:
@@ -87,7 +76,7 @@ def build_llm_action_caches(config: RailsConfig) -> Dict[str, CacheInterface]:
     return model_caches
 
 
-def initialize_llm_action_caches(rails: LLMActionCacheRails) -> None:
+def initialize_llm_action_caches(rails: LLMActionCacheSurface) -> None:
     """Initialize configured action model caches for an LLMRails instance."""
     model_caches = build_llm_action_caches(rails.config)
     if model_caches:

--- a/nemoguardrails/rails/llm/startup/llm_action_models.py
+++ b/nemoguardrails/rails/llm/startup/llm_action_models.py
@@ -17,39 +17,24 @@
 
 import logging
 import os
-from typing import Any, Callable, Dict, Protocol
+from typing import Any, Callable, Dict
 
 from nemoguardrails.exceptions import InvalidModelConfigurationError
 from nemoguardrails.llm.models.initializer import ModelInitializationError
+from nemoguardrails.rails.llm.types import LLMActionModelsSurface
 from nemoguardrails.types import LLMModel
 
-log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+log = logging.getLogger(__name__)
 
 InitLLM = Callable[..., LLMModel]
 
 __all__ = [
     "InitLLM",
-    "LLMActionRails",
-    "LLMActionRuntime",
+    "LLMActionModelsSurface",
     "load_llm_action_models",
     "model_kwargs_from_config",
     "sync_update_llm_bindings",
 ]
-
-
-class LLMActionRuntime(Protocol):
-    def register_action_param(self, name: str, value: Any) -> None: ...
-
-
-class LLMActionRails(Protocol):
-    llm: Any
-    _llm_generation_actions: Any
-
-    @property
-    def config(self) -> Any: ...
-
-    @property
-    def runtime(self) -> LLMActionRuntime: ...
 
 
 def model_kwargs_from_config(model_config: Any) -> Dict[str, Any]:
@@ -64,14 +49,14 @@ def model_kwargs_from_config(model_config: Any) -> Dict[str, Any]:
     return kwargs
 
 
-def sync_update_llm_bindings(rails: LLMActionRails, llm: LLMModel) -> None:
+def sync_update_llm_bindings(rails: LLMActionModelsSurface, llm: LLMModel) -> None:
     """Synchronize the main LLM bindings after a public update."""
     rails.llm = llm
     rails._llm_generation_actions.llm = llm
     rails.runtime.register_action_param("llm", llm)
 
 
-def load_llm_action_models(rails: LLMActionRails, init_llm: InitLLM) -> None:
+def load_llm_action_models(rails: LLMActionModelsSurface, init_llm: InitLLM) -> None:
     """Load the main and action LLMs configured for an LLMRails instance."""
     from nemoguardrails._compat.langchain_kwargs import check_langchain_kwargs
     from nemoguardrails.llm.frameworks import get_default_framework

--- a/nemoguardrails/rails/llm/streaming/__init__.py
+++ b/nemoguardrails/rails/llm/streaming/__init__.py
@@ -14,21 +14,17 @@
 # limitations under the License.
 
 from nemoguardrails.rails.llm.streaming.generation_stream import (
-    GenerationStreamRails,
+    GenerationStreamSurface,
     generation_token_stream,
 )
 from nemoguardrails.rails.llm.streaming.streaming_output_rails import (
-    StreamingOutputActionDispatcher,
-    StreamingOutputRails,
-    StreamingOutputRuntime,
+    StreamingOutputSurface,
     run_output_rails_in_streaming,
 )
 
 __all__ = [
-    "GenerationStreamRails",
-    "StreamingOutputActionDispatcher",
-    "StreamingOutputRails",
-    "StreamingOutputRuntime",
+    "GenerationStreamSurface",
+    "StreamingOutputSurface",
     "generation_token_stream",
     "run_output_rails_in_streaming",
 ]

--- a/nemoguardrails/rails/llm/streaming/generation_stream.py
+++ b/nemoguardrails/rails/llm/streaming/generation_stream.py
@@ -19,36 +19,24 @@ import asyncio
 import json
 import logging
 import warnings
-from typing import Any, AsyncIterator, Optional, Protocol, Union, cast
+from typing import Any, AsyncIterator, Optional, Union, cast
 
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.rails.llm.streaming.streaming_output_rails import (
-    StreamingOutputRails,
     run_output_rails_in_streaming,
 )
+from nemoguardrails.rails.llm.types import GenerationStreamSurface
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.utils import extract_error_json
 
 log = logging.getLogger(__name__)
 
 __all__ = [
-    "GenerationStreamRails",
+    "GenerationStreamSurface",
     "generation_token_stream",
     "validate_streaming_with_output_rails",
 ]
-
-
-class GenerationStreamRails(StreamingOutputRails, Protocol):
-    async def generate_async(
-        self,
-        *,
-        prompt: Optional[str] = None,
-        messages: Optional[list[dict]] = None,
-        options: Optional[Union[dict, GenerationOptions]] = None,
-        state: Optional[Any] = None,
-        streaming_handler: Optional[StreamingHandler] = None,
-    ) -> object: ...
 
 
 def validate_streaming_with_output_rails(config: Any) -> None:
@@ -64,7 +52,7 @@ def validate_streaming_with_output_rails(config: Any) -> None:
 
 
 def generation_token_stream(
-    rails: GenerationStreamRails,
+    rails: GenerationStreamSurface,
     *,
     prompt: Optional[str] = None,
     messages: Optional[list[dict]] = None,
@@ -149,7 +137,7 @@ def generation_token_stream(
     return wrapped_iterator()
 
 
-def _track_generation_task(rails: GenerationStreamRails, task: asyncio.Task) -> None:
+def _track_generation_task(rails: GenerationStreamSurface, task: asyncio.Task) -> None:
     """Track background stream tasks so they are not garbage collected."""
     task_holder = cast(Any, rails)
     if not hasattr(task_holder, "_active_tasks"):

--- a/nemoguardrails/rails/llm/streaming/streaming_output_rails.py
+++ b/nemoguardrails/rails/llm/streaming/streaming_output_rails.py
@@ -18,57 +18,24 @@
 import json
 import logging
 from functools import partial
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Protocol
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
 from nemoguardrails.actions.output_mapping import is_output_blocked
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig
+from nemoguardrails.rails.llm.types import StreamingOutputSurface
 from nemoguardrails.rails.llm.utils import get_action_details_from_flow_id
 
 log = logging.getLogger(__name__)
 
 __all__ = [
-    "StreamingOutputActionDispatcher",
-    "StreamingOutputRails",
-    "StreamingOutputRuntime",
+    "StreamingOutputSurface",
     "run_output_rails_in_streaming",
 ]
 
 
-class StreamingOutputActionDispatcher(Protocol):
-    async def execute_action(self, action_name: str, params: Dict[str, Any]) -> Any: ...
-
-    def get_action(self, name: str, /) -> Any: ...
-
-
-class StreamingOutputRuntime(Protocol):
-    @property
-    def action_dispatcher(self) -> StreamingOutputActionDispatcher: ...
-
-    @property
-    def llm_task_manager(self) -> Any: ...
-
-    @property
-    def registered_action_params(self) -> Dict[str, Any]: ...
-
-
-class StreamingOutputRails(Protocol):
-    _explain_info: Any
-
-    @property
-    def config(self) -> Any: ...
-
-    @property
-    def runtime(self) -> StreamingOutputRuntime: ...
-
-    @property
-    def llm(self) -> Any: ...
-
-    def _ensure_explain_info(self) -> Any: ...
-
-
 async def run_output_rails_in_streaming(
-    rails: StreamingOutputRails,
+    rails: StreamingOutputSurface,
     streaming_handler: AsyncIterator[str],
     output_rails_streaming_config: OutputRailsStreamingConfig,
     prompt: Optional[str] = None,
@@ -139,7 +106,7 @@ async def run_output_rails_in_streaming(
 
 async def _run_parallel_output_rails(
     *,
-    rails: StreamingOutputRails,
+    rails: StreamingOutputSurface,
     output_rails_flows_id: List[str],
     get_action_details: Callable[[str], tuple[str, Dict[str, Any]]],
     bot_response_chunk: str,
@@ -196,7 +163,7 @@ async def _run_parallel_output_rails(
 
 async def _run_sequential_output_rails(
     *,
-    rails: StreamingOutputRails,
+    rails: StreamingOutputSurface,
     output_rails_flows_id: List[str],
     get_action_details: Callable[[str], tuple[str, Dict[str, Any]]],
     bot_response_chunk: str,
@@ -279,7 +246,7 @@ def _create_events_for_chunk(chunk_str: str, context: dict) -> List[dict]:
 
 def _prepare_params(
     *,
-    rails: StreamingOutputRails,
+    rails: StreamingOutputSurface,
     flow_id: str,
     action_name: str,
     bot_response_chunk: str,

--- a/nemoguardrails/rails/llm/types.py
+++ b/nemoguardrails/rails/llm/types.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural typing contracts for the extracted ``rails.llm`` helper modules.
+
+``LLMRails`` is decomposed into focused helper modules (``startup``, ``runtime``,
+``conversation``, ``generation``, ``streaming``, ``checks``). Each helper depends
+on only a narrow slice of the ``LLMRails`` instance.
+
+This module expresses those slices along two axes:
+
+* **Capabilities** (``Has*`` / ``Supports*``): one single-role Protocol per
+  member-or-method an extracted helper touches, declared exactly once.
+* **Contexts**: one Protocol per helper role, assembled by composing the
+  capabilities it needs (Protocol multiple inheritance), covering exactly what
+  that helper reads/writes/calls and nothing more.
+
+These are deliberately **structural**, not pinned to the concrete ``RailsConfig``
+/ ``Runtime`` / ``ExplainInfo`` classes: a helper unit treats ``config`` and
+``runtime`` as opaque collaborators, so a lightweight stand-in (a
+``SimpleNamespace`` config, a minimal fake runtime) that is valid for the unit
+also satisfies its protocol. The concrete types are enforced at the production
+call site (``LLMRails``), where ``config`` and ``runtime`` are already statically
+typed.
+
+Variance is deliberate. A member a helper *reassigns* (``rails.x = ...``) is a
+plain attribute annotation (``x: Any``); ``Any`` keeps the invariant-attribute
+match permissive. A member a helper only *reads* is a read-only ``@property`` so
+it is covariant: a concrete attribute, a ``property``, or a fake all satisfy it,
+which a mutable (invariant) attribute annotation would reject.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol, Union
+
+from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.streaming import StreamingHandler
+
+__all__ = [
+    "ColangTurnSurface",
+    "ConversationEventSurface",
+    "GenerationActionsSurface",
+    "GenerationStreamSurface",
+    "KnowledgeBaseSurface",
+    "LLMActionCacheSurface",
+    "LLMActionModelsSurface",
+    "RailsCheckSurface",
+    "StandardGenerationSurface",
+    "StreamingOutputSurface",
+]
+
+
+# capabilities: one role each, declared exactly once.
+
+
+class HasConfig(Protocol):
+    """Reads the rails configuration (treated as an opaque collaborator)."""
+
+    @property
+    def config(self) -> Any: ...
+
+
+class HasRuntime(Protocol):
+    """Reaches the Colang runtime (action registration, dispatch, turn execution)."""
+
+    @property
+    def runtime(self) -> Any: ...
+
+
+class HasLLM(Protocol):
+    """Holds the main LLM; reassigned by the startup model wiring."""
+
+    llm: Any
+
+
+class HasGenerationActions(Protocol):
+    """Holds the LLM generation actions object; reassigned during startup."""
+
+    _llm_generation_actions: Any
+
+
+class HasKnowledgeBase(Protocol):
+    """Holds the knowledge base; assigned by knowledge-base init."""
+
+    _kb: Any
+
+
+class SupportsEmbeddingSearchProvider(Protocol):
+    """Exposes the embedding-search provider factory seam (patchable/overridable)."""
+
+    def _get_embeddings_search_provider_instance(self, esp_config: Any = None) -> Any: ...
+
+
+class HasExplainInfo(Protocol):
+    """Holds the per-instance ExplainInfo; assigned by the generation workflow."""
+
+    _explain_info: Any
+
+
+class SupportsEnsureExplainInfo(Protocol):
+    """Lazily materializes the request-scoped ExplainInfo; result is stored/forwarded."""
+
+    def _ensure_explain_info(self) -> Any: ...
+
+
+class HasLogAdapters(Protocol):
+    """Reads the tracing log adapters configured at startup."""
+
+    @property
+    def _log_adapters(self) -> Any: ...
+
+
+class HasEventsHistoryCache(Protocol):
+    """Reads the events-history cache (entries are mutated in place, not rebound)."""
+
+    @property
+    def events_history_cache(self) -> Dict[str, List[dict]]: ...
+
+
+class HasVerbose(Protocol):
+    """Reads the verbose flag (a ``property`` on the concrete class)."""
+
+    @property
+    def verbose(self) -> bool: ...
+
+
+class SupportsGenerateAsync(Protocol):
+    """Drives a full async generation pass; mirrors ``LLMRails.generate_async``."""
+
+    async def generate_async(
+        self,
+        *,
+        prompt: Optional[str] = None,
+        messages: Optional[List[dict]] = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        state: Optional[Any] = None,
+        streaming_handler: Optional[StreamingHandler] = None,
+    ) -> Any: ...
+
+
+# contexts: one per helper role, composed from the capabilities it uses.
+
+
+class LLMActionModelsSurface(HasConfig, HasRuntime, HasLLM, HasGenerationActions, Protocol):
+    """Surface used by ``startup.llm_action_models`` (load + sync model bindings)."""
+
+
+class LLMActionCacheSurface(HasConfig, HasRuntime, Protocol):
+    """Surface used by ``startup.llm_action_caches``."""
+
+
+class GenerationActionsSurface(
+    HasConfig, HasRuntime, HasLLM, HasGenerationActions, SupportsEmbeddingSearchProvider, Protocol
+):
+    """Surface used by ``startup.generation_actions`` to register LLM actions."""
+
+
+class KnowledgeBaseSurface(HasConfig, HasRuntime, SupportsEmbeddingSearchProvider, HasKnowledgeBase, Protocol):
+    """Surface used by ``startup.knowledge_base`` to build and register the KB."""
+
+
+class ConversationEventSurface(HasConfig, HasEventsHistoryCache, Protocol):
+    """Surface used by ``conversation.conversation_events``."""
+
+
+class ColangTurnSurface(HasConfig, HasRuntime, HasVerbose, Protocol):
+    """Surface used by ``runtime.colang_turns`` to run a Colang turn."""
+
+
+class StandardGenerationSurface(ConversationEventSurface, ColangTurnSurface, HasExplainInfo, HasLogAdapters, Protocol):
+    """Surface used by ``generation.generation_workflow`` (the standard generate pass)."""
+
+
+class StreamingOutputSurface(HasConfig, HasRuntime, HasLLM, HasExplainInfo, SupportsEnsureExplainInfo, Protocol):
+    """Surface used by ``streaming.streaming_output_rails`` (output rails over a stream)."""
+
+
+class GenerationStreamSurface(StreamingOutputSurface, SupportsGenerateAsync, Protocol):
+    """Surface used by ``streaming.generation_stream`` (token stream + output rails)."""
+
+
+class RailsCheckSurface(Protocol):
+    """Surface used by ``checks.rails_check``.
+
+    Narrower than ``SupportsGenerateAsync``: the check path only ever drives
+    ``generate_async`` with ``messages``/``options``, so a double that supports
+    just those satisfies the contract without growing the streaming arguments.
+    """
+
+    async def generate_async(self, *, messages: List[dict], options: dict) -> Any: ...

--- a/tests/rails/llm/test_conversation_events.py
+++ b/tests/rails/llm/test_conversation_events.py
@@ -39,7 +39,7 @@ def make_rails(config: RailsConfig):
 
 def test_conversation_events_public_exports():
     assert conversation_events.__all__ == [
-        "ConversationEventRails",
+        "ConversationEventSurface",
         "events_for_messages",
         "events_history_cache_prefix",
     ]

--- a/tests/rails/llm/test_knowledge_base.py
+++ b/tests/rails/llm/test_knowledge_base.py
@@ -25,6 +25,7 @@ from nemoguardrails.rails.llm.startup.knowledge_base import (
     build_knowledge_base_for_docs,
     init_knowledge_base,
 )
+from nemoguardrails.rails.llm.types import KnowledgeBaseSurface
 
 
 class RuntimeWithActionParams:
@@ -137,7 +138,7 @@ def test_init_knowledge_base_uses_thread_path_and_registers_kb(monkeypatch):
     monkeypatch.setattr(knowledge_base.threading, "Thread", FakeThread)
     monkeypatch.setattr(knowledge_base, "get_or_create_event_loop", lambda: object())
 
-    init_knowledge_base(rails)
+    init_knowledge_base(cast(KnowledgeBaseSurface, rails))
 
     assert rails._kb is built_kb
     assert rails.runtime.registered_action_params["kb"] is built_kb

--- a/tests/rails/llm/test_llmrails_hardening.py
+++ b/tests/rails/llm/test_llmrails_hardening.py
@@ -59,13 +59,15 @@ def _rails(config: RailsConfig | None = None) -> LLMRails:
 
 
 @pytest.mark.asyncio
-async def test_generate_standard_info_logs_keep_llmrails_logger_name(caplog):
+async def test_generate_standard_info_logs_use_generation_workflow_logger(caplog):
     with caplog.at_level(logging.INFO):
         await _rails().generate_async(messages=[{"role": "user", "content": "hi"}])
 
     total_processing_logs = [record for record in caplog.records if "--- :: Total processing took" in record.message]
 
-    assert [record.name for record in total_processing_logs] == ["nemoguardrails.rails.llm.llmrails"]
+    assert [record.name for record in total_processing_logs] == [
+        "nemoguardrails.rails.llm.generation.generation_workflow"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -572,7 +572,7 @@ NO_MAIN_LLM_WARNING = "No main LLM specified in the config and no LLM provided v
 
 class TestNoMainLLMWarning:
     def test_init_logs_info_not_warning(self, no_main_llm_config, caplog):
-        with caplog.at_level(logging.INFO, logger="nemoguardrails.rails.llm.llmrails"):
+        with caplog.at_level(logging.INFO, logger="nemoguardrails.rails.llm.startup.llm_action_models"):
             LLMRails(no_main_llm_config)
         matches = [r for r in caplog.records if NO_MAIN_LLM_WARNING in r.message]
         assert len(matches) == 1


### PR DESCRIPTION
## Description

Consolidates extracted-helper typing contracts into `rails.llm.types` as reusable capability protocols and per-helper `*Surface` protocols, and standardizes extracted helper loggers. Reviewers can see the narrow LLMRails surface each helper depends on in one place, without local protocol drift or coupling helpers back to the concrete LLMRails class.

### What changed

- Adds `nemoguardrails.rails.llm.types` for shared structural typing contracts.
- Splits contracts into `Has*` / `Supports*` capabilities and per-helper `*Surface` contexts.
- Replaces local protocol definitions with imports from the shared surfaces.
- Makes read-only vs reassigned members explicit through property vs attribute protocol forms.
- Uses per-module logger names for extracted helpers.

### Review notes

`types.py` is intentionally the home for these contracts: it is a type-only module, not a runtime owner. The `*Surface` suffix avoids overloading the existing `Rails`, `Runtime`, `Context`, or `State` meanings in the codebase.

### Stack

Part 7 of 9. Previous: #43. Next: #47.

This fork-only draft stack restacks the LLMRails decomposition so each PR adds a focused helper boundary while removing or delegating the matching code from `llmrails.py`. LLMRails stays the public compatibility shell while ownership moves into startup, conversation / Colang turns, generation, streaming, checks, shared extracted-module types, and package ownership boundaries.

Please review each PR against its parent branch, not the root base, except part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #38 | `restack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #39 | `restack/llmrails-02-startup` | `restack/llmrails-01-public-contract-tests` |
| 3 | #40 | `restack/llmrails-03-runtime-conversation` | `restack/llmrails-02-startup` |
| 4 | #41 | `restack/llmrails-04-generation` | `restack/llmrails-03-runtime-conversation` |
| 5 | #42 | `restack/llmrails-05-streaming` | `restack/llmrails-04-generation` |
| 6 | #43 | `restack/llmrails-06-checks-final` | `restack/llmrails-05-streaming` |
| 7 | #45 | `restack/llmrails-07-consistency` | `restack/llmrails-06-checks-final` |
| 8 | #47 | `restack/llmrails-08-boundary-ownership` | `restack/llmrails-07-consistency` |
| 9 | #48 | `restack/llmrails-09-followups` | `restack/llmrails-08-boundary-ownership` |

## Related Issue(s)

<!-- (maintainer to complete) -->

## Verification

```text
poetry run pre-commit run --all-files
make test
```

Full suite green on the rebased stack (`4810 passed, 180 skipped`). Stack rebased onto `origin/develop` (`fb73f41b0`).

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
